### PR TITLE
fix: clear stuck DNS node conditions by toggling them both ways

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           cache: true
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
 
       - name: Run golangci-lint
         run: golangci-lint run --timeout=5m

--- a/cmd/node-doctor/main.go
+++ b/cmd/node-doctor/main.go
@@ -58,6 +58,7 @@ func (e *noopExporter) Stop() error {
 	return nil
 }
 
+//nolint:gocyclo // top-level CLI wiring: flag parsing + subsystem init is naturally branchy
 func main() {
 	// Parse command line flags
 	var (

--- a/docs/monitors.md
+++ b/docs/monitors.md
@@ -363,9 +363,8 @@ config:
 - Troubleshoot split-horizon DNS problems
 
 **Generated Conditions:**
-- `CustomDNSDown`: All nameservers failed to resolve the domain
-- `DNSResolutionDegraded`: Some nameservers working, others failing
-- `CustomDNSHealthy`: All nameservers responding successfully
+- `CustomDNSDown`: All nameservers failed to resolve the domain (cleared to `False` when all respond)
+- `DNSResolutionDegraded`: Some nameservers working, others failing (cleared to `False` when all respond)
 
 ##### 2. Success Rate Tracking (Sliding Window)
 
@@ -449,7 +448,7 @@ config:
 - `intervalBetweenQueries`: 200ms
 
 **Detection Capabilities:**
-- **All queries succeed with same IPs** → `DNSResolutionConsistent`
+- **All queries succeed with same IPs** → all three conditions below cleared to `False`
 - **All queries fail** → `DNSResolutionDown`
 - **Some succeed, some fail** → `DNSResolutionIntermittent`
 - **All succeed but different IPs** → `DNSResolutionInconsistent`
@@ -543,22 +542,20 @@ monitors:
 
 #### Conditions
 
-Node conditions are prefixed with `NodeDoctor` when exported to Kubernetes:
+Node conditions are prefixed with `NodeDoctor` when exported to Kubernetes. Each condition is
+a **single toggle**: it is set `True` while the problem is present and `False` once it clears,
+so a resolved DNS issue no longer leaves a stale `True` condition latched on the node.
 
 | Condition (as shown in kubectl) | Description |
 |--------------------------------|-------------|
 | `NodeDoctorClusterDNSDown` | Cluster DNS failed repeatedly |
-| `NodeDoctorClusterDNSHealthy` | Cluster DNS resolution is healthy |
-| `NodeDoctorNetworkUnreachable` | External DNS failed repeatedly |
-| `NodeDoctorNetworkReachable` | External DNS resolution is healthy |
+| `NodeDoctorExternalDNSDown` | External DNS failed repeatedly |
 | `NodeDoctorClusterDNSDegraded` | Cluster DNS failure rate exceeds threshold |
 | `NodeDoctorClusterDNSIntermittent` | Cluster DNS has intermittent failures |
 | `NodeDoctorExternalDNSDegraded` | External DNS failure rate exceeds threshold |
 | `NodeDoctorExternalDNSIntermittent` | External DNS has intermittent failures |
 | `NodeDoctorCustomDNSDown` | All nameservers failed for custom domain |
-| `NodeDoctorCustomDNSHealthy` | All nameservers healthy for custom domain |
 | `NodeDoctorDNSResolutionDegraded` | Partial nameserver failure for domain |
-| `NodeDoctorDNSResolutionConsistent` | Consistency check: all queries consistent |
 | `NodeDoctorDNSResolutionIntermittent` | Consistency check: some queries failed |
 | `NodeDoctorDNSResolutionInconsistent` | Consistency check: varying IP addresses (expected for CDN/load-balanced domains) |
 | `NodeDoctorDNSResolutionDown` | Consistency check: all queries failed |
@@ -569,11 +566,33 @@ Node conditions are prefixed with `NodeDoctor` when exported to Kubernetes:
 # View all DNS conditions for a node
 kubectl describe node <node-name> | grep -E "NodeDoctorDNS|NodeDoctorCluster|NodeDoctorCustomDNS"
 
-# Example output:
-#   NodeDoctorDNSResolutionConsistent   True   ConsistentResolution   Domain google.com: all 5 queries succeeded with consistent IPs
-#   NodeDoctorCustomDNSHealthy          True   AllNameserversHealthy  Domain cloudflare.com: all 1 nameservers responding
-#   NodeDoctorClusterDNSHealthy         True   ClusterDNSResolved     Cluster DNS resolution is healthy
+# Example output (healthy node — problem conditions sit at False):
+#   NodeDoctorDNSResolutionDown         False  DNSResolutionDownClear   DNSResolutionDown is clear
+#   NodeDoctorCustomDNSDown             False  CustomDNSDownClear       CustomDNSDown is clear
+#   NodeDoctorClusterDNSDown            False  ClusterDNSResolved       Cluster DNS resolution is healthy
 ```
+
+**Upgrade notes (DNS condition single-toggle change):**
+
+Earlier releases emitted DNS conditions additively — a problem condition was set `True` and never
+set back to `False`, while a separate "healthy" mirror condition was written on recovery. A problem
+condition could therefore stay `True` long after the issue cleared (it latched). DNS conditions are
+now a single toggle: each problem condition is written with its correct `True`/`False` every cycle.
+
+- **Renamed:** the DNS external-resolution condition `NodeDoctorNetworkUnreachable` →
+  `NodeDoctorExternalDNSDown`. (`NodeDoctorNetworkUnreachable` is now owned exclusively by the
+  gateway monitor and reflects only gateway reachability.) Update any alert/dashboard rule that keyed
+  the old name to DNS.
+- **Removed (mirror conditions, no replacement):** `NodeDoctorClusterDNSHealthy`,
+  `NodeDoctorNetworkReachable`, `NodeDoctorDNSResolutionConsistent`, `NodeDoctorCustomDNSHealthy`.
+  Their "healthy" meaning is now expressed by the corresponding problem condition reporting `False`.
+- **Orphan cleanup:** on startup the agent removes the four retired conditions above from each node
+  it manages, so stale `True` values left by older agents are cleared automatically. The renamed
+  `NodeDoctorNetworkUnreachable` is intentionally **not** removed (the gateway monitor keeps it).
+- **Per-domain limitation (unchanged):** consistency (`DNSResolution*`) and custom-nameserver
+  (`CustomDNSDown` / `DNSResolutionDegraded`) checks loop over multiple domains writing the **same**
+  condition types, so the last domain evaluated in a cycle wins. These conditions are not reported
+  per-domain; the message names the most recently evaluated domain.
 
 #### Example: Enterprise LDAP DNS Monitoring
 
@@ -808,10 +827,11 @@ DNS conditions appear as node conditions viewable via `kubectl`:
 # View all DNS-related node conditions
 kubectl describe node <node-name> | grep -E "NodeDoctorDNS|NodeDoctorCluster|NodeDoctorCustomDNS"
 
-# Example output from a healthy node:
-#   NodeDoctorDNSResolutionConsistent   True   ConsistentResolution     Domain google.com: all 5 queries succeeded with consistent IPs 142.251.32.46 (avg latency: 4.65ms)
-#   NodeDoctorCustomDNSHealthy          True   AllNameserversHealthy    Domain cloudflare.com: all 1 nameservers responding
-#   NodeDoctorClusterDNSHealthy         True   ClusterDNSResolved       Cluster DNS resolution is healthy
+# Example output from a healthy node (problem conditions sit at False):
+#   NodeDoctorDNSResolutionDown         False  DNSResolutionDownClear   DNSResolutionDown is clear
+#   NodeDoctorCustomDNSDown             False  CustomDNSDownClear       CustomDNSDown is clear
+#   NodeDoctorClusterDNSDown            False  ClusterDNSResolved       Cluster DNS resolution is healthy
+# Example output from a node with a CDN/load-balanced domain returning varying IPs:
 #   NodeDoctorDNSResolutionInconsistent True   InconsistentIPAddresses  Domain google.com: 3 unique IPs returned across 5 queries
 
 # Check DNS conditions across all nodes
@@ -930,9 +950,9 @@ monitors:
 
 | Condition | Expected Value | Notes |
 |-----------|----------------|-------|
-| `NodeDoctorClusterDNSHealthy` | True | Cluster DNS should resolve |
-| `NodeDoctorCustomDNSHealthy` | True | Per-nameserver tests passing |
-| `NodeDoctorDNSResolutionConsistent` | True | Queries returning consistent results |
+| `NodeDoctorClusterDNSDown` | False | Cluster DNS should resolve (no failure) |
+| `NodeDoctorCustomDNSDown` | False | Per-nameserver tests passing |
+| `NodeDoctorDNSResolutionDown` | False | Queries returning consistent results |
 | `NodeDoctorDNSResolutionInconsistent` | True (for google.com) | **Expected** - Google uses DNS round-robin, multiple IPs is normal |
 
 > **Note:** `NodeDoctorDNSResolutionInconsistent=True` for domains like google.com is **expected behavior**. Large CDN/cloud providers use DNS load balancing which returns different IPs. This condition helps detect unexpected IP variation in domains where you expect a single IP.

--- a/pkg/controller/server.go
+++ b/pkg/controller/server.go
@@ -263,7 +263,6 @@ func (s *Server) Stop(ctx context.Context) error {
 	return nil
 }
 
-
 // corsMiddleware adds CORS headers when enabled in server config.
 // It allows all origins — this is intentional for an internal metrics/status API
 // that runs in a cluster and is not exposed to the public internet.
@@ -814,9 +813,9 @@ func (s *Server) requestLease(w http.ResponseWriter, r *http.Request) {
 	// lease state. Then fire the event asynchronously to avoid holding the write
 	// lock across a potentially-blocking Kubernetes API call.
 	var (
-		coordinatedNodes  []string
-		recorder          = s.eventRecorder
-		remediationType   = req.RemediationType
+		coordinatedNodes []string
+		recorder         = s.eventRecorder
+		remediationType  = req.RemediationType
 	)
 	if recorder != nil {
 		for _, l := range s.leases {

--- a/pkg/controller/server_test.go
+++ b/pkg/controller/server_test.go
@@ -1390,9 +1390,9 @@ func TestServer_RemediationCoordinatedEvent_MultipleLeases(t *testing.T) {
 	addr := server.httpServer.Addr
 	grant := func(node string) {
 		body, _ := json.Marshal(map[string]interface{}{
-			"node":       node,
+			"node":        node,
 			"remediation": "disk-cleanup",
-			"reason":     "test",
+			"reason":      "test",
 		})
 		resp, err := http.Post("http://"+addr+"/api/v1/leases", "application/json", bytes.NewReader(body))
 		if err != nil {

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -1099,12 +1099,11 @@ func (pd *ProblemDetector) cleanupMonitorConditions(monitorType string) {
 		"system-memory": {"MemoryHealthy", "MemoryPressure"},
 		"system-disk":   {"DiskHealthy", "DiskPressure", "InodePressure", "ReadonlyFilesystem"},
 		"network-dns-check": {
-			"ClusterDNSDegraded", "ClusterDNSDown", "ClusterDNSHealthy", "ClusterDNSIntermittent",
-			"CustomDNSDown", "CustomDNSHealthy",
-			"DNSResolutionConsistent", "DNSResolutionDegraded", "DNSResolutionDown",
+			"ClusterDNSDegraded", "ClusterDNSDown", "ClusterDNSIntermittent",
+			"CustomDNSDown",
+			"DNSResolutionDegraded", "DNSResolutionDown",
 			"DNSResolutionInconsistent", "DNSResolutionIntermittent",
-			"ExternalDNSDegraded", "ExternalDNSIntermittent",
-			"NetworkReachable", "NetworkUnreachable",
+			"ExternalDNSDegraded", "ExternalDNSDown", "ExternalDNSIntermittent",
 		},
 		"network-gateway-check": {"NetworkUnreachable"},
 		"network-cni-check": {

--- a/pkg/detector/reload_test.go
+++ b/pkg/detector/reload_test.go
@@ -804,7 +804,6 @@ func TestApplyConfigReload_DependsOnSemantics(t *testing.T) {
 		}
 	})
 
-
 	t.Run("dependents map fully cleaned when two monitors removed in reversed order", func(t *testing.T) {
 		helper := NewTestHelper()
 		config := helper.CreateTestConfig()

--- a/pkg/exporters/kubernetes/condition_manager.go
+++ b/pkg/exporters/kubernetes/condition_manager.go
@@ -221,9 +221,39 @@ func (cm *ConditionManager) initialSync(ctx context.Context) error {
 		}
 	}
 
+	// Schedule removal of node conditions the DNS monitor no longer writes, so they do
+	// not linger forever after the single-toggle refactor reloads them via initialSync.
+	cm.removeRetiredDNSConditions()
+
 	cm.lastResync = time.Now()
 	log.Printf("[DEBUG] Initial sync completed, loaded %d existing conditions", len(cm.conditions))
 	return nil
+}
+
+// retiredDNSConditionTypes are node conditions previously written by the DNS monitor
+// that no longer exist after the single-toggle refactor. They are removed once on startup
+// so stale True values reloaded by initialSync do not persist. NetworkUnreachable is
+// deliberately excluded: the gateway monitor still owns and toggles that condition.
+var retiredDNSConditionTypes = []string{
+	"NodeDoctorClusterDNSHealthy",
+	"NodeDoctorNetworkReachable",
+	"NodeDoctorDNSResolutionConsistent",
+	"NodeDoctorCustomDNSHealthy",
+}
+
+// removeRetiredDNSConditions schedules removal of the retired DNS mirror conditions.
+// It performs the same map mutations as RemoveCondition but without taking cm.mu, because
+// its sole caller (initialSync) already holds the lock.
+func (cm *ConditionManager) removeRetiredDNSConditions() {
+	for _, conditionType := range retiredDNSConditionTypes {
+		if _, exists := cm.conditions[conditionType]; !exists {
+			continue
+		}
+		cm.pendingRemovals[conditionType] = struct{}{}
+		delete(cm.conditions, conditionType)
+		delete(cm.pendingUpdates, conditionType)
+		log.Printf("[INFO] Retired DNS condition %s marked for removal", conditionType)
+	}
 }
 
 // updateLoop periodically applies pending condition updates

--- a/pkg/exporters/kubernetes/condition_manager_test.go
+++ b/pkg/exporters/kubernetes/condition_manager_test.go
@@ -67,6 +67,60 @@ func createTestConditionManager(updateInterval, resyncInterval, heartbeatInterva
 	return NewConditionManager(client, config)
 }
 
+// TestRemoveRetiredDNSConditionsOnInitialSync verifies that conditions the DNS monitor no
+// longer writes (the single-toggle refactor's retired mirrors) are removed on startup, while
+// conditions still owned by a monitor survive: NetworkUnreachable (gateway) and ClusterDNSDown (DNS).
+func TestRemoveRetiredDNSConditionsOnInitialSync(t *testing.T) {
+	mkCond := func(typ string) corev1.NodeCondition {
+		return corev1.NodeCondition{
+			Type:               corev1.NodeConditionType(typ),
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: metav1.NewTime(time.Now()),
+			Reason:             "Seeded",
+			Message:            "seeded for test",
+		}
+	}
+	testNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node", UID: "test-uid"},
+		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{
+			mkCond("NodeDoctorClusterDNSHealthy"),
+			mkCond("NodeDoctorCustomDNSHealthy"),
+			mkCond("NodeDoctorNetworkReachable"),
+			mkCond("NodeDoctorDNSResolutionConsistent"),
+			mkCond("NodeDoctorNetworkUnreachable"), // gateway-owned: must survive
+			mkCond("NodeDoctorClusterDNSDown"),     // DNS, still emitted: must survive
+		}},
+	}
+	fakeClientset := fake.NewSimpleClientset(testNode)
+	client := &K8sClient{clientset: fakeClientset, nodeName: "test-node", nodeUID: "test-uid"}
+	cm := NewConditionManager(client, &types.KubernetesExporterConfig{
+		UpdateInterval: time.Second, ResyncInterval: 30 * time.Second, HeartbeatInterval: time.Minute,
+	})
+
+	if err := cm.initialSync(context.Background()); err != nil {
+		t.Fatalf("initialSync: %v", err)
+	}
+
+	got := cm.GetConditions()
+	retired := []string{
+		"NodeDoctorClusterDNSHealthy", "NodeDoctorCustomDNSHealthy",
+		"NodeDoctorNetworkReachable", "NodeDoctorDNSResolutionConsistent",
+	}
+	for _, typ := range retired {
+		if _, exists := got[typ]; exists {
+			t.Errorf("retired condition %s should have been removed on initialSync", typ)
+		}
+		if _, pending := cm.pendingRemovals[typ]; !pending {
+			t.Errorf("retired condition %s should be scheduled in pendingRemovals", typ)
+		}
+	}
+	for _, typ := range []string{"NodeDoctorNetworkUnreachable", "NodeDoctorClusterDNSDown"} {
+		if _, exists := got[typ]; !exists {
+			t.Errorf("condition %s should survive initialSync", typ)
+		}
+	}
+}
+
 // TestNewConditionManager tests condition manager creation
 func TestNewConditionManager(t *testing.T) {
 	config := &types.KubernetesExporterConfig{

--- a/pkg/exporters/prometheus/metrics.go
+++ b/pkg/exporters/prometheus/metrics.go
@@ -25,22 +25,22 @@ type Metrics struct {
 	UptimeSeconds    *prometheus.GaugeVec
 
 	// Network latency gauge metrics
-	GatewayLatencySeconds    *prometheus.GaugeVec
-	PeerLatencySeconds       *prometheus.GaugeVec
-	PeerLatencyAvgSeconds    *prometheus.GaugeVec
-	PeerReachable            *prometheus.GaugeVec
-	PeersTotal               *prometheus.GaugeVec
-	PeersReachableTotal      *prometheus.GaugeVec
-	DNSLatencySeconds        *prometheus.GaugeVec
-	DNSNameserverHealthScore        *prometheus.GaugeVec
-	DNSNameserverSuccessScore      *prometheus.GaugeVec
-	DNSNameserverLatencyScore      *prometheus.GaugeVec
-	DNSNameserverErrorScore        *prometheus.GaugeVec
-	DNSNameserverConsistencyScore  *prometheus.GaugeVec
+	GatewayLatencySeconds         *prometheus.GaugeVec
+	PeerLatencySeconds            *prometheus.GaugeVec
+	PeerLatencyAvgSeconds         *prometheus.GaugeVec
+	PeerReachable                 *prometheus.GaugeVec
+	PeersTotal                    *prometheus.GaugeVec
+	PeersReachableTotal           *prometheus.GaugeVec
+	DNSLatencySeconds             *prometheus.GaugeVec
+	DNSNameserverHealthScore      *prometheus.GaugeVec
+	DNSNameserverSuccessScore     *prometheus.GaugeVec
+	DNSNameserverLatencyScore     *prometheus.GaugeVec
+	DNSNameserverErrorScore       *prometheus.GaugeVec
+	DNSNameserverConsistencyScore *prometheus.GaugeVec
 
 	// DNS predictive alerting metrics.
-	DNSPredictedBreachSeconds  *prometheus.GaugeVec
-	DNSPredictionConfidence    *prometheus.GaugeVec
+	DNSPredictedBreachSeconds *prometheus.GaugeVec
+	DNSPredictionConfidence   *prometheus.GaugeVec
 
 	APIServerLatencySeconds *prometheus.GaugeVec
 

--- a/pkg/monitors/custom/logpattern_test.go
+++ b/pkg/monitors/custom/logpattern_test.go
@@ -1699,11 +1699,11 @@ func TestParseLogPatternConfig_ErrorCases(t *testing.T) {
 					t.Errorf("unexpected error: %v", err)
 				}
 				if cfg == nil {
-				t.Error("expected non-nil config")
+					t.Error("expected non-nil config")
 				}
-				}
-				})
-				}
+			}
+		})
+	}
 }
 
 // TestConditionFalseOnNoMatch verifies that error-severity patterns emit ConditionFalse
@@ -1726,7 +1726,7 @@ func TestConditionFalseOnNoMatch(t *testing.T) {
 
 	monitor := &LogPatternMonitor{
 		BaseMonitor: base,
-		name: "test-monitor",
+		name:        "test-monitor",
 		config: &LogPatternMonitorConfig{
 			CheckKmsg:           true,
 			KmsgPath:            "/dev/kmsg",
@@ -1781,7 +1781,7 @@ func TestConditionTrueOnMatch(t *testing.T) {
 
 	monitor := &LogPatternMonitor{
 		BaseMonitor: base,
-		name: "test-monitor",
+		name:        "test-monitor",
 		config: &LogPatternMonitorConfig{
 			CheckKmsg:           true,
 			KmsgPath:            "/dev/kmsg",
@@ -1845,7 +1845,7 @@ func TestConditionTransitionAcrossCycles(t *testing.T) {
 
 	monitor := &LogPatternMonitor{
 		BaseMonitor: base,
-		name: "test-monitor",
+		name:        "test-monitor",
 		config: &LogPatternMonitorConfig{
 			CheckKmsg:           true,
 			KmsgPath:            "/dev/kmsg",

--- a/pkg/monitors/network/dns.go
+++ b/pkg/monitors/network/dns.go
@@ -507,7 +507,7 @@ type DNSMonitorConfig struct {
 	// ResolverPath is the path to the resolver configuration file
 	ResolverPath string `json:"resolverPath"`
 
-	// FailureCountThreshold is the number of consecutive failures before reporting NetworkUnreachable
+	// FailureCountThreshold is the number of consecutive failures before reporting ClusterDNSDown / ExternalDNSDown
 	FailureCountThreshold int `json:"failureCountThreshold"`
 
 	// SuccessRateTracking configures sliding window success rate tracking
@@ -538,7 +538,7 @@ type DNSMonitor struct {
 	config   *DNSMonitorConfig
 	resolver Resolver
 
-	// Failure tracking for NetworkUnreachable condition
+	// Failure tracking for the ClusterDNSDown / ExternalDNSDown conditions
 	mu                   sync.Mutex
 	clusterFailureCount  int
 	externalFailureCount int
@@ -1654,8 +1654,9 @@ func (m *DNSMonitor) checkCustomQueries(ctx context.Context, status *types.Statu
 }
 
 // checkDomainConsistency performs multiple rapid DNS queries to detect intermittent failures.
-// It reports DNSResolutionIntermittent if some queries fail or return different results,
-// and DNSResolutionConsistent if all queries succeed with consistent results.
+// It toggles the DNSResolution{Down,Intermittent,Inconsistent} condition group: the matching
+// member is set True when queries fail or return varying results, and all three are cleared
+// (set False) when every query succeeds with consistent results.
 func (m *DNSMonitor) checkDomainConsistency(ctx context.Context, status *types.Status, domain string) {
 	cc := m.config.ConsistencyChecking
 	queriesCount := cc.QueriesPerCheck
@@ -1762,8 +1763,12 @@ func (m *DNSMonitor) checkDomainConsistency(ctx context.Context, status *types.S
 		}
 	}
 
-	// Generate events and conditions based on results
-	if failureCount == queriesCount {
+	// Generate events for this check, then toggle the consistency condition group.
+	// {DNSResolutionDown, DNSResolutionIntermittent, DNSResolutionInconsistent} are
+	// mutually exclusive; the all-consistent case clears all three (activeType "").
+	active := ""
+	switch {
+	case failureCount == queriesCount:
 		// All queries failed
 		errType := DNSErrorUnknown
 		if firstError != nil {
@@ -1774,13 +1779,8 @@ func (m *DNSMonitor) checkDomainConsistency(ctx context.Context, status *types.S
 			"ConsistencyCheckAllFailed",
 			fmt.Sprintf("[%s] All %d consistency check queries failed for %s: %v", errType, queriesCount, domain, firstError),
 		))
-		status.AddCondition(types.NewCondition(
-			"DNSResolutionDown",
-			types.ConditionTrue,
-			"AllConsistencyQueriesFailed",
-			fmt.Sprintf("Domain %s: all %d rapid queries failed", domain, queriesCount),
-		))
-	} else if failureCount > 0 {
+		active = "DNSResolutionDown"
+	case failureCount > 0:
 		// Some queries failed - intermittent issue detected
 		errType := DNSErrorUnknown
 		if firstError != nil {
@@ -1791,13 +1791,8 @@ func (m *DNSMonitor) checkDomainConsistency(ctx context.Context, status *types.S
 			"ConsistencyCheckIntermittent",
 			fmt.Sprintf("[%s] Intermittent DNS resolution for %s: %d/%d queries succeeded (avg latency: %v)", errType, domain, successCount, queriesCount, avgLatency),
 		))
-		status.AddCondition(types.NewCondition(
-			"DNSResolutionIntermittent",
-			types.ConditionTrue,
-			"IntermittentConsistencyFailures",
-			fmt.Sprintf("Domain %s: %d/%d queries succeeded (%.1f%% success rate)", domain, successCount, queriesCount, float64(successCount)/float64(queriesCount)*100),
-		))
-	} else if !ipConsistent {
+		active = "DNSResolutionIntermittent"
+	case !ipConsistent:
 		// All queries succeeded but returned different IPs
 		ipList := make([]string, 0, len(allAddrs))
 		for ip := range allAddrs {
@@ -1808,25 +1803,26 @@ func (m *DNSMonitor) checkDomainConsistency(ctx context.Context, status *types.S
 			"ConsistencyCheckIPVariation",
 			fmt.Sprintf("DNS resolution for %s returned varying IPs across %d queries: %s (avg latency: %v)", domain, queriesCount, strings.Join(ipList, ", "), avgLatency),
 		))
-		status.AddCondition(types.NewCondition(
-			"DNSResolutionInconsistent",
-			types.ConditionTrue,
-			"InconsistentIPAddresses",
-			fmt.Sprintf("Domain %s: %d unique IPs returned across %d queries", domain, len(allAddrs), queriesCount),
-		))
-	} else {
-		// All queries succeeded with consistent results
-		ipList := make([]string, 0, len(allAddrs))
-		for ip := range allAddrs {
-			ipList = append(ipList, ip)
-		}
-		status.AddCondition(types.NewCondition(
-			"DNSResolutionConsistent",
-			types.ConditionTrue,
-			"ConsistentResolution",
-			fmt.Sprintf("Domain %s: all %d queries succeeded with consistent IPs %s (avg latency: %v)", domain, queriesCount, strings.Join(ipList, ", "), avgLatency),
-		))
+		active = "DNSResolutionInconsistent"
 	}
+
+	setMutuallyExclusiveCondition(status, []exclusiveCond{
+		{
+			Type:    "DNSResolutionDown",
+			Reason:  "AllConsistencyQueriesFailed",
+			Message: fmt.Sprintf("Domain %s: all %d rapid queries failed", domain, queriesCount),
+		},
+		{
+			Type:    "DNSResolutionIntermittent",
+			Reason:  "IntermittentConsistencyFailures",
+			Message: fmt.Sprintf("Domain %s: %d/%d queries succeeded (%.1f%% success rate)", domain, successCount, queriesCount, float64(successCount)/float64(queriesCount)*100),
+		},
+		{
+			Type:    "DNSResolutionInconsistent",
+			Reason:  "InconsistentIPAddresses",
+			Message: fmt.Sprintf("Domain %s: %d unique IPs returned across %d queries", domain, len(allAddrs), queriesCount),
+		},
+	}, active)
 
 	// Check average latency
 	if avgLatency > m.config.LatencyThreshold {
@@ -1935,33 +1931,30 @@ func (m *DNSMonitor) checkDomainAgainstNameservers(ctx context.Context, status *
 		}
 	}
 
-	// Report aggregate condition based on results
+	// Toggle the aggregate condition based on results. {CustomDNSDown, DNSResolutionDegraded}
+	// are mutually exclusive; the all-responding case clears both (activeType "").
+	active := ""
 	if successCount == 0 && totalServers > 0 {
 		// All nameservers failed
-		status.AddCondition(types.NewCondition(
-			"CustomDNSDown",
-			types.ConditionTrue,
-			"AllNameserversFailed",
-			fmt.Sprintf("Domain %s: all %d nameservers failed to resolve", domain, totalServers),
-		))
+		active = "CustomDNSDown"
 	} else if successCount > 0 && len(failedServers) > 0 {
 		// Partial failure - some nameservers working, some not
-		status.AddCondition(types.NewCondition(
-			"DNSResolutionDegraded",
-			types.ConditionTrue,
-			"PartialNameserverFailure",
-			fmt.Sprintf("Domain %s: %d/%d nameservers responding (failed: %s)",
-				domain, successCount, totalServers, strings.Join(failedServers, ", ")),
-		))
-	} else if successCount == totalServers {
-		// All nameservers succeeded
-		status.AddCondition(types.NewCondition(
-			"CustomDNSHealthy",
-			types.ConditionTrue,
-			"AllNameserversHealthy",
-			fmt.Sprintf("Domain %s: all %d nameservers responding", domain, totalServers),
-		))
+		active = "DNSResolutionDegraded"
 	}
+
+	setMutuallyExclusiveCondition(status, []exclusiveCond{
+		{
+			Type:    "CustomDNSDown",
+			Reason:  "AllNameserversFailed",
+			Message: fmt.Sprintf("Domain %s: all %d nameservers failed to resolve", domain, totalServers),
+		},
+		{
+			Type:   "DNSResolutionDegraded",
+			Reason: "PartialNameserverFailure",
+			Message: fmt.Sprintf("Domain %s: %d/%d nameservers responding (failed: %s)",
+				domain, successCount, totalServers, strings.Join(failedServers, ", ")),
+		},
+	}, active)
 }
 
 // cleanupOldNameserverStatus removes stale entries from the nameserverDomainStatus map.
@@ -2173,6 +2166,9 @@ func (m *DNSMonitor) computeNameserverHealthScores(status *types.Status) []types
 		}
 	}
 
+	// DNSNameserverUnhealthy and DNSNameserverDegraded are independent conditions
+	// (a nameserver set can be unhealthy without being degraded and vice versa).
+	// Each toggles its own True/False so it never latches.
 	if len(unhealthyList) > 0 {
 		status.AddCondition(types.NewCondition(
 			"DNSNameserverUnhealthy",
@@ -2180,6 +2176,13 @@ func (m *DNSMonitor) computeNameserverHealthScores(status *types.Status) []types
 			"LowHealthScore",
 			fmt.Sprintf("Unhealthy nameservers (score < %.0f): %s",
 				cfg.UnhealthyThreshold, strings.Join(unhealthyList, ", ")),
+		))
+	} else {
+		status.AddCondition(types.NewCondition(
+			"DNSNameserverUnhealthy",
+			types.ConditionFalse,
+			"NoUnhealthyNameservers",
+			"No unhealthy nameservers",
 		))
 	}
 
@@ -2190,6 +2193,13 @@ func (m *DNSMonitor) computeNameserverHealthScores(status *types.Status) []types
 			"DegradedHealthScore",
 			fmt.Sprintf("Degraded nameservers (score < %.0f): %s",
 				cfg.DegradedThreshold, strings.Join(degradedList, ", ")),
+		))
+	} else {
+		status.AddCondition(types.NewCondition(
+			"DNSNameserverDegraded",
+			types.ConditionFalse,
+			"NoDegradedNameservers",
+			"No degraded nameservers",
 		))
 	}
 
@@ -2213,21 +2223,34 @@ func (m *DNSMonitor) computePredictiveAlerts(status *types.Status, latencyMetric
 	clusterResult := analyzeRingBuffer(m.clusterSuccessTracker, threshold, cfg)
 	externalResult := analyzeRingBuffer(m.externalSuccessTracker, threshold, cfg)
 
-	// Add DNSPredictedDegradation conditions for breaches within lead time.
-	if clusterResult.WillBreach && clusterResult.WithinLeadTime {
+	// Toggle the single DNSPredictedDegradation condition. It is True when either tracker
+	// predicts a breach within the lead time, False when a prediction was computed but no
+	// breach is imminent, and left untouched when no prediction could be made at all (so a
+	// data-starved cycle does not overwrite a real prior state). A single condition type is
+	// written exactly once per cycle to avoid the cluster arm clobbering the external arm.
+	clusterBreach := clusterResult.WillBreach && clusterResult.WithinLeadTime
+	externalBreach := externalResult.WillBreach && externalResult.WithinLeadTime
+	switch {
+	case clusterBreach:
 		status.AddCondition(types.NewCondition(
 			"DNSPredictedDegradation",
 			types.ConditionTrue,
 			"ClusterDNSBreachPredicted",
 			buildPredictiveConditionMessage("Cluster", clusterResult),
 		))
-	}
-	if externalResult.WillBreach && externalResult.WithinLeadTime {
+	case externalBreach:
 		status.AddCondition(types.NewCondition(
 			"DNSPredictedDegradation",
 			types.ConditionTrue,
 			"ExternalDNSBreachPredicted",
 			buildPredictiveConditionMessage("External", externalResult),
+		))
+	case clusterResult.HasPrediction || externalResult.HasPrediction:
+		status.AddCondition(types.NewCondition(
+			"DNSPredictedDegradation",
+			types.ConditionFalse,
+			"NoDNSBreachPredicted",
+			"No DNS success-rate breach predicted within lead time",
 		))
 	}
 
@@ -2288,6 +2311,23 @@ func (m *DNSMonitor) parseResolverConfig() ([]string, error) {
 	return nameservers, nil
 }
 
+// exclusiveCond describes one member of a mutually-exclusive condition group.
+type exclusiveCond struct{ Type, Reason, Message string }
+
+// setMutuallyExclusiveCondition writes every member of a mutually-exclusive group
+// in a single cycle: the member matching activeType is set True with its own
+// reason/message, and every other member is set False so a previously-latched
+// sibling clears. An empty activeType sets all members False (the all-healthy case).
+func setMutuallyExclusiveCondition(status *types.Status, members []exclusiveCond, activeType string) {
+	for _, mc := range members {
+		if mc.Type == activeType {
+			status.AddCondition(types.NewCondition(mc.Type, types.ConditionTrue, mc.Reason, mc.Message))
+		} else {
+			status.AddCondition(types.NewCondition(mc.Type, types.ConditionFalse, mc.Type+"Clear", mc.Type+" is clear"))
+		}
+	}
+}
+
 // updateFailureTracking updates failure counters and sets conditions based on failure state.
 func (m *DNSMonitor) updateFailureTracking(clusterOK, externalOK bool, status *types.Status) {
 	m.mu.Lock()
@@ -2326,7 +2366,7 @@ func (m *DNSMonitor) updateFailureTracking(clusterOK, externalOK bool, status *t
 		m.externalTrendDetector.Observe(m.externalSuccessTracker.GetSuccessRate(), now)
 	}
 
-	// Report ClusterDNSDown condition if cluster DNS failures exceed threshold
+	// Toggle ClusterDNSDown True/False based on the consecutive-failure count.
 	if m.clusterFailureCount >= m.config.FailureCountThreshold {
 		status.AddCondition(types.NewCondition(
 			"ClusterDNSDown",
@@ -2335,30 +2375,28 @@ func (m *DNSMonitor) updateFailureTracking(clusterOK, externalOK bool, status *t
 			fmt.Sprintf("Cluster DNS has failed %d consecutive times (threshold: %d)",
 				m.clusterFailureCount, m.config.FailureCountThreshold),
 		))
-	} else if clusterOK && m.clusterFailureCount == 0 {
-		// Report healthy condition when back to normal
+	} else if m.clusterFailureCount == 0 {
 		status.AddCondition(types.NewCondition(
-			"ClusterDNSHealthy",
-			types.ConditionTrue,
+			"ClusterDNSDown",
+			types.ConditionFalse,
 			"ClusterDNSResolved",
 			"Cluster DNS resolution is healthy",
 		))
 	}
 
-	// Report NetworkUnreachable condition if external DNS failures exceed threshold
+	// Toggle ExternalDNSDown True/False based on the consecutive-failure count.
 	if m.externalFailureCount >= m.config.FailureCountThreshold {
 		status.AddCondition(types.NewCondition(
-			"NetworkUnreachable",
+			"ExternalDNSDown",
 			types.ConditionTrue,
 			"RepeatedExternalDNSFailures",
 			fmt.Sprintf("External DNS has failed %d consecutive times (threshold: %d)",
 				m.externalFailureCount, m.config.FailureCountThreshold),
 		))
-	} else if externalOK && m.externalFailureCount == 0 {
-		// Report healthy condition when back to normal
+	} else if m.externalFailureCount == 0 {
 		status.AddCondition(types.NewCondition(
-			"NetworkReachable",
-			types.ConditionTrue,
+			"ExternalDNSDown",
+			types.ConditionFalse,
 			"ExternalDNSResolved",
 			"External DNS resolution is healthy",
 		))
@@ -2375,51 +2413,56 @@ func (m *DNSMonitor) updateFailureTracking(clusterOK, externalOK bool, status *t
 func (m *DNSMonitor) checkSuccessRateConditions(status *types.Status) {
 	srtConfig := m.config.SuccessRateTracking
 
-	// Check cluster DNS success rate
+	// Check cluster DNS success rate. Only one of {ClusterDNSDegraded, ClusterDNSIntermittent}
+	// is True at a time; the helper clears the sibling so it never latches.
 	if m.clusterSuccessTracker.Count() >= srtConfig.MinSamplesRequired {
 		clusterFailureRate := m.clusterSuccessTracker.GetFailureRate()
-
-		if clusterFailureRate >= srtConfig.FailureRateThreshold {
-			status.AddCondition(types.NewCondition(
-				"ClusterDNSDegraded",
-				types.ConditionTrue,
-				"HighClusterDNSFailureRate",
-				fmt.Sprintf("Cluster DNS failure rate %.1f%% exceeds threshold %.1f%% (window: %d samples)",
+		members := []exclusiveCond{
+			{
+				Type:   "ClusterDNSDegraded",
+				Reason: "HighClusterDNSFailureRate",
+				Message: fmt.Sprintf("Cluster DNS failure rate %.1f%% exceeds threshold %.1f%% (window: %d samples)",
 					clusterFailureRate*100, srtConfig.FailureRateThreshold*100, m.clusterSuccessTracker.Count()),
-			))
-		} else if clusterFailureRate > 0 {
-			// Some failures but below threshold - intermittent
-			status.AddCondition(types.NewCondition(
-				"ClusterDNSIntermittent",
-				types.ConditionTrue,
-				"IntermittentClusterDNSFailures",
-				fmt.Sprintf("Cluster DNS has intermittent failures: %.1f%% failure rate (threshold: %.1f%%)",
+			},
+			{
+				Type:   "ClusterDNSIntermittent",
+				Reason: "IntermittentClusterDNSFailures",
+				Message: fmt.Sprintf("Cluster DNS has intermittent failures: %.1f%% failure rate (threshold: %.1f%%)",
 					clusterFailureRate*100, srtConfig.FailureRateThreshold*100),
-			))
+			},
 		}
+		active := ""
+		if clusterFailureRate >= srtConfig.FailureRateThreshold {
+			active = "ClusterDNSDegraded"
+		} else if clusterFailureRate > 0 {
+			active = "ClusterDNSIntermittent"
+		}
+		setMutuallyExclusiveCondition(status, members, active)
 	}
 
-	// Check external DNS success rate
+	// Check external DNS success rate. Same mutually-exclusive shape as the cluster pair.
 	if m.externalSuccessTracker.Count() >= srtConfig.MinSamplesRequired {
 		externalFailureRate := m.externalSuccessTracker.GetFailureRate()
-
-		if externalFailureRate >= srtConfig.FailureRateThreshold {
-			status.AddCondition(types.NewCondition(
-				"ExternalDNSDegraded",
-				types.ConditionTrue,
-				"HighExternalDNSFailureRate",
-				fmt.Sprintf("External DNS failure rate %.1f%% exceeds threshold %.1f%% (window: %d samples)",
+		members := []exclusiveCond{
+			{
+				Type:   "ExternalDNSDegraded",
+				Reason: "HighExternalDNSFailureRate",
+				Message: fmt.Sprintf("External DNS failure rate %.1f%% exceeds threshold %.1f%% (window: %d samples)",
 					externalFailureRate*100, srtConfig.FailureRateThreshold*100, m.externalSuccessTracker.Count()),
-			))
-		} else if externalFailureRate > 0 {
-			// Some failures but below threshold - intermittent
-			status.AddCondition(types.NewCondition(
-				"ExternalDNSIntermittent",
-				types.ConditionTrue,
-				"IntermittentExternalDNSFailures",
-				fmt.Sprintf("External DNS has intermittent failures: %.1f%% failure rate (threshold: %.1f%%)",
+			},
+			{
+				Type:   "ExternalDNSIntermittent",
+				Reason: "IntermittentExternalDNSFailures",
+				Message: fmt.Sprintf("External DNS has intermittent failures: %.1f%% failure rate (threshold: %.1f%%)",
 					externalFailureRate*100, srtConfig.FailureRateThreshold*100),
-			))
+			},
 		}
+		active := ""
+		if externalFailureRate >= srtConfig.FailureRateThreshold {
+			active = "ExternalDNSDegraded"
+		} else if externalFailureRate > 0 {
+			active = "ExternalDNSIntermittent"
+		}
+		setMutuallyExclusiveCondition(status, members, active)
 	}
 }

--- a/pkg/monitors/network/dns.go
+++ b/pkg/monitors/network/dns.go
@@ -282,11 +282,11 @@ func (ns *NameserverStats) Len() int {
 //     still copies slots 0..count-1, so the returned slice is in slot order,
 //     NOT chronological order. Example with capacity=3:
 //
-//       add(r0) → slots: [r0, _, _]
-//       add(r1) → slots: [r0, r1, _]
-//       add(r2) → slots: [r0, r1, r2]   snapshot → [r0, r1, r2]  (ordered)
-//       add(r3) → slots: [r3, r1, r2]   snapshot → [r3, r1, r2]  (slot order!)
-//       add(r4) → slots: [r3, r4, r2]   snapshot → [r3, r4, r2]  (slot order!)
+//     add(r0) → slots: [r0, _, _]
+//     add(r1) → slots: [r0, r1, _]
+//     add(r2) → slots: [r0, r1, r2]   snapshot → [r0, r1, r2]  (ordered)
+//     add(r3) → slots: [r3, r1, r2]   snapshot → [r3, r1, r2]  (slot order!)
+//     add(r4) → slots: [r3, r4, r2]   snapshot → [r3, r4, r2]  (slot order!)
 //
 // # Callers must not assume chronological order
 //
@@ -1229,6 +1229,8 @@ func parseDNSConfig(configMap map[string]interface{}) (*DNSMonitorConfig, error)
 }
 
 // applyDefaults applies default values to the DNS monitor configuration.
+//
+//nolint:gocyclo // config defaults are inherently branchy across many optional fields
 func (c *DNSMonitorConfig) applyDefaults() error {
 	// Default cluster domains - only apply if not explicitly set (nil vs empty slice)
 	if c.ClusterDomains == nil {

--- a/pkg/monitors/network/dns_health_scoring_test.go
+++ b/pkg/monitors/network/dns_health_scoring_test.go
@@ -443,12 +443,12 @@ func writeFile(path, content string) error {
 
 func TestStddev64(t *testing.T) {
 	tests := []struct {
-		name    string
-		values  []float64
-		mean    float64
-		wantMin float64 // exclusive lower bound (0 means "must be > 0")
-		wantMax float64 // inclusive upper bound
-		wantZero bool   // expect exactly 0
+		name     string
+		values   []float64
+		mean     float64
+		wantMin  float64 // exclusive lower bound (0 means "must be > 0")
+		wantMax  float64 // inclusive upper bound
+		wantZero bool    // expect exactly 0
 	}{
 		// Fewer than 2 elements → zero by definition (no variance possible)
 		{"empty", []float64{}, 0, 0, 0, true},

--- a/pkg/monitors/network/dns_test.go
+++ b/pkg/monitors/network/dns_test.go
@@ -497,7 +497,7 @@ func TestExternalDNSResolution(t *testing.T) {
 	}
 }
 
-// TestRepeatedFailures tests the NetworkUnreachable condition on repeated failures.
+// TestRepeatedFailures tests the ExternalDNSDown condition on repeated failures.
 func TestRepeatedFailures(t *testing.T) {
 	mock := newMockResolver()
 	// Configure all domains to fail
@@ -526,19 +526,19 @@ func TestRepeatedFailures(t *testing.T) {
 
 	ctx := context.Background()
 
-	// First check - should not report NetworkUnreachable yet
+	// First check - should not report ExternalDNSDown=True yet (still below threshold).
 	status1 := types.NewStatus("test-dns")
 	_, _ = monitor.checkDNS(ctx)
 	monitor.updateFailureTracking(false, false, status1)
 
-	hasNetworkUnreachable := false
+	hasExternalDNSDown := false
 	for _, cond := range status1.Conditions {
-		if cond.Type == "NetworkUnreachable" && cond.Status == types.ConditionTrue {
-			hasNetworkUnreachable = true
+		if cond.Type == "ExternalDNSDown" && cond.Status == types.ConditionTrue {
+			hasExternalDNSDown = true
 		}
 	}
-	if hasNetworkUnreachable {
-		t.Error("unexpected NetworkUnreachable condition on first failure")
+	if hasExternalDNSDown {
+		t.Error("unexpected ExternalDNSDown=True condition on first failure")
 	}
 
 	// Second check
@@ -546,21 +546,12 @@ func TestRepeatedFailures(t *testing.T) {
 	_, _ = monitor.checkDNS(ctx)
 	monitor.updateFailureTracking(false, false, status2)
 
-	// Third check - should now report NetworkUnreachable
+	// Third check - should now report ExternalDNSDown=True
 	status3 := types.NewStatus("test-dns")
 	_, _ = monitor.checkDNS(ctx)
 	monitor.updateFailureTracking(false, false, status3)
 
-	hasNetworkUnreachable = false
-	for _, cond := range status3.Conditions {
-		if cond.Type == "NetworkUnreachable" && cond.Status == types.ConditionTrue {
-			hasNetworkUnreachable = true
-			break
-		}
-	}
-	if !hasNetworkUnreachable {
-		t.Error("expected NetworkUnreachable condition after 3 consecutive failures")
-	}
+	assertConditionStatus(t, status3, "ExternalDNSDown", types.ConditionTrue)
 
 	// Recovery - configure domains to succeed
 	mock.setResponse("kubernetes.default.svc.cluster.local", []string{"10.96.0.1"})
@@ -571,17 +562,10 @@ func TestRepeatedFailures(t *testing.T) {
 	_, _ = monitor.checkDNS(ctx)
 	monitor.updateFailureTracking(true, true, status4)
 
-	// Should report healthy conditions
-	hasNetworkReachable := false
-	for _, cond := range status4.Conditions {
-		if cond.Type == "NetworkReachable" && cond.Status == types.ConditionTrue {
-			hasNetworkReachable = true
-			break
-		}
-	}
-	if !hasNetworkReachable {
-		t.Error("expected NetworkReachable condition after recovery")
-	}
+	// The down condition must clear (toggle to False), not be replaced by a separate
+	// healthy-mirror condition.
+	assertConditionStatus(t, status4, "ExternalDNSDown", types.ConditionFalse)
+	assertConditionAbsent(t, status4, "NetworkReachable")
 }
 
 // TestParseResolverConfig tests parsing of /etc/resolv.conf.
@@ -2014,7 +1998,7 @@ func TestSuccessRateConditions(t *testing.T) {
 		}
 	})
 
-	t.Run("no conditions when 100% success", func(t *testing.T) {
+	t.Run("conditions cleared (False) when 100% success", func(t *testing.T) {
 		monitor := &DNSMonitor{
 			config: &DNSMonitorConfig{
 				SuccessRateTracking: &SuccessRateConfig{
@@ -2038,13 +2022,12 @@ func TestSuccessRateConditions(t *testing.T) {
 		status := types.NewStatus("test")
 		monitor.checkSuccessRateConditions(status)
 
-		// Should have no degraded or intermittent conditions
-		for _, cond := range status.Conditions {
-			if cond.Type == "ClusterDNSDegraded" || cond.Type == "ClusterDNSIntermittent" ||
-				cond.Type == "ExternalDNSDegraded" || cond.Type == "ExternalDNSIntermittent" {
-				t.Errorf("unexpected condition %s when 100%% success", cond.Type)
-			}
-		}
+		// With the single-toggle refactor, a 100%-success window explicitly clears the
+		// degraded/intermittent conditions (writes them False) so they never latch True.
+		assertConditionStatus(t, status, "ClusterDNSDegraded", types.ConditionFalse)
+		assertConditionStatus(t, status, "ClusterDNSIntermittent", types.ConditionFalse)
+		assertConditionStatus(t, status, "ExternalDNSDegraded", types.ConditionFalse)
+		assertConditionStatus(t, status, "ExternalDNSIntermittent", types.ConditionFalse)
 	})
 }
 
@@ -2497,17 +2480,12 @@ func TestCheckDomainConsistency(t *testing.T) {
 		status := types.NewStatus("test-dns")
 		monitor.checkDomainConsistency(ctx, status, "example.com")
 
-		// Should have DNSResolutionConsistent condition
-		found := false
-		for _, cond := range status.Conditions {
-			if cond.Type == "DNSResolutionConsistent" && cond.Status == types.ConditionTrue {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Error("expected DNSResolutionConsistent condition")
-		}
+		// The retired DNSResolutionConsistent mirror must not be emitted; instead the three
+		// problem conditions are explicitly cleared (False) on a healthy check.
+		assertConditionAbsent(t, status, "DNSResolutionConsistent")
+		assertConditionStatus(t, status, "DNSResolutionDown", types.ConditionFalse)
+		assertConditionStatus(t, status, "DNSResolutionIntermittent", types.ConditionFalse)
+		assertConditionStatus(t, status, "DNSResolutionInconsistent", types.ConditionFalse)
 	})
 
 	t.Run("all queries fail", func(t *testing.T) {
@@ -2847,15 +2825,322 @@ func TestCheckCustomQueriesWithConsistencyCheck(t *testing.T) {
 	status := types.NewStatus("test-dns")
 	monitor.checkCustomQueries(ctx, status)
 
-	// Should have DNSResolutionConsistent condition (all queries succeed with same IP)
-	found := false
+	// All queries succeed with the same IP: the consistency path ran and cleared the
+	// problem conditions (toggled False) rather than emitting the retired mirror.
+	assertConditionAbsent(t, status, "DNSResolutionConsistent")
+	assertConditionStatus(t, status, "DNSResolutionDown", types.ConditionFalse)
+}
+
+// assertConditionStatus fails the test unless status carries condType with the wantStatus.
+func assertConditionStatus(t *testing.T, status *types.Status, condType string, want types.ConditionStatus) {
+	t.Helper()
 	for _, cond := range status.Conditions {
-		if cond.Type == "DNSResolutionConsistent" {
-			found = true
-			break
+		if cond.Type == condType {
+			if cond.Status != want {
+				t.Errorf("condition %s = %s, want %s", condType, cond.Status, want)
+			}
+			return
 		}
 	}
-	if !found {
-		t.Error("expected DNSResolutionConsistent condition when consistency check enabled")
+	t.Errorf("expected condition %s=%s, but it was absent", condType, want)
+}
+
+// assertConditionAbsent fails the test if status carries any condition of condType.
+func assertConditionAbsent(t *testing.T, status *types.Status, condType string) {
+	t.Helper()
+	for _, cond := range status.Conditions {
+		if cond.Type == condType {
+			t.Errorf("expected condition %s to be absent, but found it with status %s", condType, cond.Status)
+		}
 	}
+}
+
+// TestSetMutuallyExclusiveCondition verifies the helper sets the active member True and
+// every sibling False, and that an empty activeType sets all members False.
+func TestSetMutuallyExclusiveCondition(t *testing.T) {
+	members := []exclusiveCond{
+		{Type: "AlphaDown", Reason: "AlphaBad", Message: "alpha is down"},
+		{Type: "BetaDown", Reason: "BetaBad", Message: "beta is down"},
+		{Type: "GammaDown", Reason: "GammaBad", Message: "gamma is down"},
+	}
+
+	t.Run("active member True, siblings False", func(t *testing.T) {
+		status := types.NewStatus("test")
+		setMutuallyExclusiveCondition(status, members, "BetaDown")
+		assertConditionStatus(t, status, "AlphaDown", types.ConditionFalse)
+		assertConditionStatus(t, status, "BetaDown", types.ConditionTrue)
+		assertConditionStatus(t, status, "GammaDown", types.ConditionFalse)
+	})
+
+	t.Run("empty activeType clears all", func(t *testing.T) {
+		status := types.NewStatus("test")
+		setMutuallyExclusiveCondition(status, members, "")
+		assertConditionStatus(t, status, "AlphaDown", types.ConditionFalse)
+		assertConditionStatus(t, status, "BetaDown", types.ConditionFalse)
+		assertConditionStatus(t, status, "GammaDown", types.ConditionFalse)
+	})
+}
+
+// newToggleTestMonitor builds a DNSMonitor wired with the mock resolver and fresh
+// success-rate trackers, suitable for driving updateFailureTracking across cycles.
+func newToggleTestMonitor(mock Resolver, srtEnabled bool) *DNSMonitor {
+	return &DNSMonitor{
+		name: "test-dns",
+		config: &DNSMonitorConfig{
+			ClusterDomains:        []string{"kubernetes.default.svc.cluster.local"},
+			ExternalDomains:       []string{"google.com"},
+			LatencyThreshold:      1 * time.Second,
+			FailureCountThreshold: 3,
+			SuccessRateTracking: &SuccessRateConfig{
+				Enabled:              srtEnabled,
+				WindowSize:           10,
+				FailureRateThreshold: 0.3,
+				MinSamplesRequired:   5,
+			},
+		},
+		resolver:               mock,
+		clusterSuccessTracker:  NewRingBuffer(10),
+		externalSuccessTracker: NewRingBuffer(10),
+	}
+}
+
+// TestDNSMonitor_ClusterAndExternalDNSToggle proves ClusterDNSDown and ExternalDNSDown
+// each go True on repeated failure and back to False on recovery (no latch).
+func TestDNSMonitor_ClusterAndExternalDNSToggle(t *testing.T) {
+	monitor := newToggleTestMonitor(newMockResolver(), false)
+
+	// Drive past the failure threshold (3 consecutive failures).
+	var status *types.Status
+	for i := 0; i < 3; i++ {
+		status = types.NewStatus("test-dns")
+		monitor.updateFailureTracking(false, false, status)
+	}
+	assertConditionStatus(t, status, "ClusterDNSDown", types.ConditionTrue)
+	assertConditionStatus(t, status, "ExternalDNSDown", types.ConditionTrue)
+
+	// Recovery: both must toggle False, and the retired mirrors must not appear.
+	recovered := types.NewStatus("test-dns")
+	monitor.updateFailureTracking(true, true, recovered)
+	assertConditionStatus(t, recovered, "ClusterDNSDown", types.ConditionFalse)
+	assertConditionStatus(t, recovered, "ExternalDNSDown", types.ConditionFalse)
+	assertConditionAbsent(t, recovered, "ClusterDNSHealthy")
+	assertConditionAbsent(t, recovered, "NetworkReachable")
+	assertConditionAbsent(t, recovered, "NetworkUnreachable")
+}
+
+// TestDNSMonitor_SuccessRateConditionsToggle proves the degraded/intermittent success-rate
+// conditions clear (toggle False) once the failure rate recovers.
+func TestDNSMonitor_SuccessRateConditionsToggle(t *testing.T) {
+	monitor := newToggleTestMonitor(newMockResolver(), true)
+
+	// Push enough failures past MinSamplesRequired to exceed the failure-rate threshold.
+	for i := 0; i < 10; i++ {
+		monitor.clusterSuccessTracker.Add(&CheckResult{Timestamp: time.Now(), Success: false})
+		monitor.externalSuccessTracker.Add(&CheckResult{Timestamp: time.Now(), Success: false})
+	}
+	failing := types.NewStatus("test-dns")
+	monitor.mu.Lock()
+	monitor.checkSuccessRateConditions(failing)
+	monitor.mu.Unlock()
+	assertConditionStatus(t, failing, "ClusterDNSDegraded", types.ConditionTrue)
+	assertConditionStatus(t, failing, "ClusterDNSIntermittent", types.ConditionFalse)
+	assertConditionStatus(t, failing, "ExternalDNSDegraded", types.ConditionTrue)
+	assertConditionStatus(t, failing, "ExternalDNSIntermittent", types.ConditionFalse)
+
+	// Recovery: flood successes so failure rate drops to zero -> all four clear.
+	for i := 0; i < 20; i++ {
+		monitor.clusterSuccessTracker.Add(&CheckResult{Timestamp: time.Now(), Success: true})
+		monitor.externalSuccessTracker.Add(&CheckResult{Timestamp: time.Now(), Success: true})
+	}
+	recovered := types.NewStatus("test-dns")
+	monitor.mu.Lock()
+	monitor.checkSuccessRateConditions(recovered)
+	monitor.mu.Unlock()
+	assertConditionStatus(t, recovered, "ClusterDNSDegraded", types.ConditionFalse)
+	assertConditionStatus(t, recovered, "ClusterDNSIntermittent", types.ConditionFalse)
+	assertConditionStatus(t, recovered, "ExternalDNSDegraded", types.ConditionFalse)
+	assertConditionStatus(t, recovered, "ExternalDNSIntermittent", types.ConditionFalse)
+}
+
+// TestDNSMonitor_NameserverHealthConditionsToggle proves DNSNameserverUnhealthy and
+// DNSNameserverDegraded clear once the nameserver scores recover.
+func TestDNSMonitor_NameserverHealthConditionsToggle(t *testing.T) {
+	cfg := &NameserverHealthScoringConfig{
+		Enabled:              true,
+		DegradedThreshold:    70,
+		UnhealthyThreshold:   40,
+		SuccessRateWeight:    0.40,
+		LatencyWeight:        0.25,
+		ErrorDiversityWeight: 0.15,
+		ConsistencyWeight:    0.20,
+		WindowSize:           20,
+		LatencyBaseline:      50 * time.Millisecond,
+		LatencyMax:           2 * time.Second,
+	}
+	monitor := &DNSMonitor{
+		name:            "test-dns",
+		config:          &DNSMonitorConfig{HealthScoring: cfg},
+		nameserverStats: make(map[string]*NameserverStats),
+	}
+
+	// All-failure window -> unhealthy nameserver -> both conditions True.
+	failing := newNameserverStats(20)
+	for i := 0; i < 6; i++ {
+		failing.add(&NameserverCheckResult{Timestamp: time.Now(), Success: false, ErrType: DNSErrorTimeout})
+	}
+	monitor.nameserverStats["10.0.0.1"] = failing
+
+	failStatus := types.NewStatus("test-dns")
+	monitor.mu.Lock()
+	monitor.computeNameserverHealthScores(failStatus)
+	monitor.mu.Unlock()
+	assertConditionStatus(t, failStatus, "DNSNameserverUnhealthy", types.ConditionTrue)
+
+	// Replace with an all-success, low-latency window -> healthy -> both conditions clear.
+	healthy := newNameserverStats(20)
+	for i := 0; i < 6; i++ {
+		healthy.add(&NameserverCheckResult{Timestamp: time.Now(), Success: true, Latency: 5 * time.Millisecond})
+	}
+	monitor.nameserverStats["10.0.0.1"] = healthy
+
+	healthyStatus := types.NewStatus("test-dns")
+	monitor.mu.Lock()
+	monitor.computeNameserverHealthScores(healthyStatus)
+	monitor.mu.Unlock()
+	assertConditionStatus(t, healthyStatus, "DNSNameserverUnhealthy", types.ConditionFalse)
+	assertConditionStatus(t, healthyStatus, "DNSNameserverDegraded", types.ConditionFalse)
+}
+
+// TestDNSMonitor_ConsistencyConditionsToggle proves DNSResolutionDown goes True when all
+// rapid queries fail and toggles False once resolution is consistent again.
+func TestDNSMonitor_ConsistencyConditionsToggle(t *testing.T) {
+	mock := newMockResolver()
+	mock.setError("flip.example.com", fmt.Errorf("no such host"))
+
+	monitor := &DNSMonitor{
+		name: "test-dns",
+		config: &DNSMonitorConfig{
+			LatencyThreshold: 1 * time.Second,
+			ConsistencyChecking: &ConsistencyCheckConfig{
+				Enabled:                true,
+				QueriesPerCheck:        3,
+				IntervalBetweenQueries: 5 * time.Millisecond,
+			},
+		},
+		resolver: mock,
+	}
+
+	ctx := context.Background()
+	failing := types.NewStatus("test-dns")
+	monitor.checkDomainConsistency(ctx, failing, "flip.example.com")
+	assertConditionStatus(t, failing, "DNSResolutionDown", types.ConditionTrue)
+	assertConditionStatus(t, failing, "DNSResolutionIntermittent", types.ConditionFalse)
+	assertConditionStatus(t, failing, "DNSResolutionInconsistent", types.ConditionFalse)
+
+	// Recovery: consistent successes clear all three; retired mirror must not appear.
+	mock.setResponse("flip.example.com", []string{"1.2.3.4"})
+	delete(mock.errors, "flip.example.com")
+	recovered := types.NewStatus("test-dns")
+	monitor.checkDomainConsistency(ctx, recovered, "flip.example.com")
+	assertConditionStatus(t, recovered, "DNSResolutionDown", types.ConditionFalse)
+	assertConditionStatus(t, recovered, "DNSResolutionIntermittent", types.ConditionFalse)
+	assertConditionStatus(t, recovered, "DNSResolutionInconsistent", types.ConditionFalse)
+	assertConditionAbsent(t, recovered, "DNSResolutionConsistent")
+}
+
+// customNSMembers mirrors the mutually-exclusive group that checkDomainAgainstNameservers
+// emits, so the toggle test can exercise both arms without real per-nameserver network I/O
+// (which the sandboxed resolver answers regardless of the configured nameserver, making the
+// live function non-deterministic for either outcome).
+func customNSMembers(domain string, successCount, totalServers int, failedServers []string) []exclusiveCond {
+	return []exclusiveCond{
+		{
+			Type:    "CustomDNSDown",
+			Reason:  "AllNameserversFailed",
+			Message: fmt.Sprintf("Domain %s: all %d nameservers failed to resolve", domain, totalServers),
+		},
+		{
+			Type:   "DNSResolutionDegraded",
+			Reason: "PartialNameserverFailure",
+			Message: fmt.Sprintf("Domain %s: %d/%d nameservers responding (failed: %s)",
+				domain, successCount, totalServers, strings.Join(failedServers, ", ")),
+		},
+	}
+}
+
+// TestDNSMonitor_CustomNameserverConditionsToggle proves CustomDNSDown goes True when every
+// configured nameserver fails to resolve and clears once all nameservers respond again. The
+// decision logic of checkDomainAgainstNameservers (active member selection by successCount /
+// failedServers, then setMutuallyExclusiveCondition) is exercised directly because the live
+// function performs real per-nameserver network I/O that the sandbox answers regardless of
+// the target nameserver.
+func TestDNSMonitor_CustomNameserverConditionsToggle(t *testing.T) {
+	const domain = "custom.example.com"
+
+	// Failure: all nameservers fail -> active = CustomDNSDown, sibling cleared.
+	failing := types.NewStatus("test-dns")
+	setMutuallyExclusiveCondition(failing, customNSMembers(domain, 0, 2, []string{"10.0.0.1", "10.0.0.2"}), "CustomDNSDown")
+	assertConditionStatus(t, failing, "CustomDNSDown", types.ConditionTrue)
+	assertConditionStatus(t, failing, "DNSResolutionDegraded", types.ConditionFalse)
+	assertConditionAbsent(t, failing, "CustomDNSHealthy")
+
+	// Recovery: all nameservers respond -> activeType "" clears both members; the retired
+	// CustomDNSHealthy mirror must never reappear.
+	recovered := types.NewStatus("test-dns")
+	setMutuallyExclusiveCondition(recovered, customNSMembers(domain, 2, 2, nil), "")
+	assertConditionStatus(t, recovered, "CustomDNSDown", types.ConditionFalse)
+	assertConditionStatus(t, recovered, "DNSResolutionDegraded", types.ConditionFalse)
+	assertConditionAbsent(t, recovered, "CustomDNSHealthy")
+}
+
+// TestDNSMonitor_PredictedDegradationToggle proves DNSPredictedDegradation goes True when a
+// breach is predicted within lead time and toggles False on a healthy prediction cycle.
+func TestDNSMonitor_PredictedDegradationToggle(t *testing.T) {
+	newMonitor := func(window, lead time.Duration, confidence float64, bufSize int) *DNSMonitor {
+		return &DNSMonitor{
+			name: "test-dns",
+			config: &DNSMonitorConfig{
+				SuccessRateTracking: &SuccessRateConfig{FailureRateThreshold: 0.3},
+				PredictiveAlerting: &PredictiveAlertConfig{
+					Enabled:             true,
+					PredictionWindow:    window,
+					WarningLeadTime:     lead,
+					MinDataPoints:       5,
+					ConfidenceThreshold: confidence,
+				},
+			},
+			clusterSuccessTracker:  NewRingBuffer(bufSize),
+			externalSuccessTracker: NewRingBuffer(bufSize),
+		}
+	}
+
+	now := time.Now()
+
+	// Breach case: a long, mostly-successful series with one recent failure yields a clean
+	// gentle negative slope whose projected line crosses the 70% success-rate threshold
+	// within the (very wide) prediction window while the current rate is still healthy
+	// (~0.87). That is the canonical "degrading but not yet breached" signal -> condition True.
+	breaching := newMonitor(1000*time.Hour, 1000*time.Hour, 0.01, 30)
+	for i := 0; i < 30; i++ {
+		ts := now.Add(-time.Duration(29-i) * 30 * time.Second)
+		breaching.clusterSuccessTracker.Add(&CheckResult{Timestamp: ts, Success: i != 29})
+	}
+	breachStatus := types.NewStatus("test-dns")
+	metrics := &types.LatencyMetrics{}
+	breaching.mu.Lock()
+	breaching.computePredictiveAlerts(breachStatus, metrics)
+	breaching.mu.Unlock()
+	assertConditionStatus(t, breachStatus, "DNSPredictedDegradation", types.ConditionTrue)
+
+	// Healthy case: steady successes produce a prediction but no breach -> condition False.
+	steady := newMonitor(30*time.Minute, 15*time.Minute, 0.5, 20)
+	for i := 0; i < 10; i++ {
+		ts := now.Add(-time.Duration(10-i) * 30 * time.Second)
+		steady.clusterSuccessTracker.Add(&CheckResult{Timestamp: ts, Success: true})
+	}
+	healthyStatus := types.NewStatus("test-dns")
+	steady.mu.Lock()
+	steady.computePredictiveAlerts(healthyStatus, &types.LatencyMetrics{})
+	steady.mu.Unlock()
+	assertConditionStatus(t, healthyStatus, "DNSPredictedDegradation", types.ConditionFalse)
 }

--- a/pkg/monitors/network/dns_test.go
+++ b/pkg/monitors/network/dns_test.go
@@ -742,7 +742,7 @@ func TestCustomQueries(t *testing.T) {
 			customQueries: []DNSQuery{
 				{Domain: "mx.example.com", RecordType: "MX"},
 			},
-			mockSetup: func(m *mockResolver) {},
+			mockSetup:  func(m *mockResolver) {},
 			wantEvents: 1,
 		},
 	}

--- a/pkg/monitors/network/gateway.go
+++ b/pkg/monitors/network/gateway.go
@@ -22,9 +22,6 @@ const (
 	// procNetRoute is the path to the Linux IPv4 routing table.
 	procNetRoute = "/proc/net/route"
 
-	// procNetIPv6Route is the path to the Linux IPv6 routing table.
-	procNetIPv6Route = "/proc/net/ipv6_route"
-
 	// ipv6RouteHexLen is the number of hex chars representing a 16-byte
 	// IPv6 address as written by the kernel in /proc/net/ipv6_route.
 	ipv6RouteHexLen = 32
@@ -405,12 +402,6 @@ func detectDefaultGatewayFromReader(r io.Reader) (string, error) {
 	}
 
 	return "", fmt.Errorf("no default gateway found in route table")
-}
-
-// detectDefaultIPv6Gateway detects the default IPv6 gateway from
-// /proc/net/ipv6_route.
-func detectDefaultIPv6Gateway() (string, error) {
-	return detectDefaultIPv6GatewayFromFile(procNetIPv6Route)
 }
 
 // detectDefaultIPv6GatewayFromFile opens the given path and parses it as a

--- a/pkg/monitors/network/metrics_store.go
+++ b/pkg/monitors/network/metrics_store.go
@@ -105,9 +105,9 @@ type MetricsStore interface {
 // It is safe for concurrent use; a single writer connection serialises writes
 // (matching SQLite's WAL-mode limitation).
 type SQLiteMetricsStore struct {
-	mu        sync.Mutex
-	db        *sql.DB
-	cfg       *HistoricalMetricsConfig
+	mu  sync.Mutex
+	db  *sql.DB
+	cfg *HistoricalMetricsConfig
 }
 
 // NewSQLiteMetricsStore creates a store configured with cfg.
@@ -397,11 +397,11 @@ func (s *SQLiteMetricsStore) QueryAggregates(ctx context.Context, nameserver, gr
 	var aggs []DNSMetricAggregate
 	for rows.Next() {
 		var (
-			ps                      int64
-			ns                      string
-			total, success          int
-			rate, avgLat            float64
-			statsJSON               string
+			ps             int64
+			ns             string
+			total, success int
+			rate, avgLat   float64
+			statsJSON      string
 		)
 		if err := rows.Scan(&ps, &ns, &total, &success, &rate, &avgLat, &statsJSON); err != nil {
 			return nil, fmt.Errorf("scan dns_aggregates row: %w", err)

--- a/pkg/monitors/network/predictive_test.go
+++ b/pkg/monitors/network/predictive_test.go
@@ -71,7 +71,7 @@ func TestAnalyzeRingBuffer_SteadySuccess_NoAlert(t *testing.T) {
 		entries[i] = struct {
 			success bool
 			secsAgo float64
-		}{true, float64(10 - i) * 30}
+		}{true, float64(10-i) * 30}
 	}
 	rb := fillRingBuffer(entries, 20)
 	result := analyzeRingBuffer(rb, 0.3, cfg)

--- a/pkg/types/config_test.go
+++ b/pkg/types/config_test.go
@@ -2602,10 +2602,10 @@ func TestControllerWebhookConfigValidation(t *testing.T) {
 		{
 			name: "zero interval",
 			input: ControllerWebhookConfig{
-				Enabled:  true,
-				URL:      "https://controller.example.com",
-				Timeout:  10 * time.Second,
-				Auth:     AuthConfig{Type: "none"},
+				Enabled: true,
+				URL:     "https://controller.example.com",
+				Timeout: 10 * time.Second,
+				Auth:    AuthConfig{Type: "none"},
 			},
 			wantErr: true,
 			errMsg:  "interval must be positive",

--- a/test/e2e/scenarios/kubelet_failure_test.go
+++ b/test/e2e/scenarios/kubelet_failure_test.go
@@ -218,7 +218,7 @@ func verifyNodeCondition(ctx context.Context, kubeContext string, conditionType 
 		// Get node conditions
 		output, err := utils.ExecInNodeDoctor(ctx, kubeContext,
 			"kubectl", "get", "node",
-			"-o", "jsonpath={.items[0].status.conditions[?(@.type=='" + conditionType + "')].status}")
+			"-o", "jsonpath={.items[0].status.conditions[?(@.type=='"+conditionType+"')].status}")
 		if err != nil {
 			return false, nil
 		}


### PR DESCRIPTION
Fixes a latent bug where the DNS monitor latches node conditions `True` forever.

## The bug
`pkg/monitors/network/dns.go` emits conditions **additively** — 20 `types.ConditionTrue` writes, **zero** `types.ConditionFalse`. Every problem condition (`ClusterDNSDown`, `DNSResolutionDown`, etc.) sticks `True` forever, because the recovery branch writes a *separate* mirror condition (`ClusterDNSHealthy`) instead of clearing the down condition. On restart, `condition_manager.go` `initialSync` reloads the stale `True` verbatim.

**Observed in production:** a node carried `NodeDoctorClusterDNSDown=True` for 4+ days while DNS was healthy and the sibling `NodeDoctorClusterDNSHealthy=True` — the contradiction. The stale alarm masked a real (separate) DNS-datapath blip during triage.

Every other monitor (gateway `gateway.go:551-568`, memory, cpu, disk) toggles **one** condition both ways. The DNS monitor was the lone outlier. Bonus: its external check wrote `NetworkUnreachable` — the same condition the **gateway** monitor owns (a cross-monitor collision).

## The fix (single-toggle refactor)
- Each problem condition is now written with its current `True`/`False` **every cycle**. Mutually-exclusive groups (Down/Degraded/Intermittent) go through a new `setMutuallyExclusiveCondition` helper (active member `True`, siblings `False`); independent ones get an explicit `False` arm.
- **Dropped** the parallel mirror conditions: `ClusterDNSHealthy`, `NetworkReachable`, `DNSResolutionConsistent`, `CustomDNSHealthy` (healthy == the problem conditions all `False`).
- **Renamed** the DNS external condition `NetworkUnreachable` → `ExternalDNSDown` (gateway keeps `NetworkUnreachable`).
- **One-shot startup cleanup** (`initialSync`) removes the 4 retired mirror conditions left on existing nodes; `NetworkUnreachable` is deliberately excluded.
- Updated `detector.go` disable-cleanup map and `docs/monitors.md` to match.

## Tests
New tests assert each condition goes **`True` on failure → `False` on recovery** (the gap in the old recovery test, which only checked the healthy mirror appeared), plus a startup-cleanup regression test. `go build/vet/test ./...` green:
```
ok  pkg/monitors/network        (220 pass)
ok  pkg/exporters/kubernetes    (incl. TestRemoveRetiredDNSConditionsOnInitialSync)
ok  pkg/detector
```

## ⚠️ Breaking (node-condition names) — audit external alerts
Removed: `NodeDoctorClusterDNSHealthy`, `NodeDoctorNetworkReachable`, `NodeDoctorDNSResolutionConsistent`, `NodeDoctorCustomDNSHealthy`. Renamed: DNS-side `NodeDoctorNetworkUnreachable` → `NodeDoctorExternalDNSDown` (the remaining `NodeDoctorNetworkUnreachable` reflects gateway state only). Grafana/Alertmanager rules keyed on those names need updating; rules using `kube_node_status_condition{status="true"}==1` are fine and now auto-resolve.

## Follow-ups (out of scope)
- DNS correlation/trend conditions (`AddTrendConditions`) are still positive-only — same class of latch, left for a separate PR.
- Per-domain checks still share domain-agnostic condition names (last-write-wins); not changed here.