### PR TITLE
fix(startup): bind health server before networked exporters (stop crashloop on degraded nodes)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,6 +57,12 @@ linters-settings:
       - io.Copy
       - io.ReadAll
 
+  misspell:
+    ignore-words:
+      # "strat" = strategy (e.g. detector.go `for i, strat := range strategies`);
+      # the misspell linter wrongly flags it as a misspelling of "start".
+      - strat
+
   govet:
     enable-all: true
     disable:

--- a/cmd/node-doctor/main.go
+++ b/cmd/node-doctor/main.go
@@ -406,6 +406,42 @@ func createExporters(ctx context.Context, config *types.NodeDoctorConfig, remedi
 	// is created and started) so the caller can wire it as a circuit-state observer.
 	var promExporterTyped *prometheusexporter.PrometheusExporter
 
+	// Create the Health Server FIRST so the Kubernetes startup/liveness probe
+	// (:8080/healthz) can bind and return 200 immediately — BEFORE the k8s/HTTP
+	// exporters below, whose Start() can BLOCK on a degraded node (cluster-DNS or
+	// API-server reachability, cache sync). If a networked exporter hangs during
+	// startup, the health listener would otherwise never open within the ~110s
+	// startup budget → probe 404 → kubelet kills the agent → crashloop, on exactly
+	// the nodes node-doctor exists to observe. Bind liveness before slow init
+	// (cluster-services #19529: a1pinode01 crashlooped 125x this way).
+	log.Printf("[INFO] Creating health server...")
+	healthServer, err := health.NewServer(&health.Config{
+		Enabled: true,
+		// "::" binds dual-stack (IPv4 + IPv6) with graceful fallback to
+		// "0.0.0.0" when IPv6 is disabled on the node (handled in Start()).
+		BindAddress:  "::",
+		Port:         8080,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	})
+	if err != nil {
+		log.Printf("[WARN] Failed to create health server: %v", err)
+	} else {
+		// Wire the remediation history provider before Start so the endpoint is
+		// available immediately when the listener opens (no race window).
+		if remediationProvider != nil {
+			healthServer.SetRemediationHistory(remediationProvider)
+			log.Printf("[INFO] Remediation history wired to /remediation/history endpoint")
+		}
+		if err := healthServer.Start(ctx); err != nil {
+			log.Printf("[WARN] Failed to start health server: %v", err)
+		} else {
+			exporters = append(exporters, healthServer)
+			exporterInterfaces = append(exporterInterfaces, healthServer)
+			log.Printf("[INFO] Health server created and started on port 8080")
+		}
+	}
+
 	// Create Kubernetes exporter if enabled
 	if config.Exporters.Kubernetes != nil && config.Exporters.Kubernetes.Enabled {
 		log.Printf("[INFO] Creating Kubernetes exporter...")
@@ -443,35 +479,6 @@ func createExporters(ctx context.Context, config *types.NodeDoctorConfig, remedi
 				exporterInterfaces = append(exporterInterfaces, httpExporter)
 				log.Printf("[INFO] HTTP exporter created and started")
 			}
-		}
-	}
-
-	// Create Health Server (always enabled for Kubernetes probes)
-	log.Printf("[INFO] Creating health server...")
-	healthServer, err := health.NewServer(&health.Config{
-		Enabled: true,
-		// "::" binds dual-stack (IPv4 + IPv6) with graceful fallback to
-		// "0.0.0.0" when IPv6 is disabled on the node (handled in Start()).
-		BindAddress:  "::",
-		Port:         8080,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
-	})
-	if err != nil {
-		log.Printf("[WARN] Failed to create health server: %v", err)
-	} else {
-		// Wire the remediation history provider before Start so the endpoint is
-		// available immediately when the listener opens (no race window).
-		if remediationProvider != nil {
-			healthServer.SetRemediationHistory(remediationProvider)
-			log.Printf("[INFO] Remediation history wired to /remediation/history endpoint")
-		}
-		if err := healthServer.Start(ctx); err != nil {
-			log.Printf("[WARN] Failed to start health server: %v", err)
-		} else {
-			exporters = append(exporters, healthServer)
-			exporterInterfaces = append(exporterInterfaces, healthServer)
-			log.Printf("[INFO] Health server created and started on port 8080")
 		}
 	}
 


### PR DESCRIPTION
Fixes node-doctor CrashLoopBackOff on network-degraded nodes (cluster-services #19529).

## Problem
In `createExporters()` (cmd/node-doctor/main.go) the **Kubernetes and HTTP exporters `Start()` run before the health server `Start()`**. On a node with degraded cluster-DNS / API-server reachability, a networked exporter's `Start()` can **block**, so `:8080/healthz` never binds within the ~110s startup budget (startupProbe: initialDelay 10 + 20×5). The kubelet probe then gets **404** → the agent is killed → `CrashLoopBackOff`.

This is the worst-possible failure mode for a node health agent: it dies on **exactly the nodes it exists to observe**. Real case: `a1pinode01` crash-looped **125×** on startup-probe 404 while its Cilium agent reported healthy (49/49 controllers) — the tell that this was a health-server **bind-timing** problem, not a detector-health gate (`/healthz` registers no gating checks; nothing calls `SetHealthy`/`AddHealthCheck`).

## Fix
Create + `Start()` the health server **first**, before the k8s/HTTP/Prometheus exporters. Liveness binds immediately regardless of downstream init; the detector + exporters still start and export conditions normally. A blocked exporter now leaves the agent **up and reporting** the condition (NodeDoctorClusterDNSDown etc.) instead of crash-looping.

Pure ordering change in `createExporters()`; `go build` + `go vet` clean. No behavior change on healthy nodes.

## Note (separate)
The underlying `a1pinode01` cluster-DNS / high-peer-latency condition is a distinct node-network issue (still to be root-caused on-node / the node is a cordoned ARM Pi). This PR stops node-doctor from crash-looping so it can actually *report* that condition.