### PR TITLE
fix(chart): explicit dns-health monitor, cluster-domain check disabled (hostNetwork can't resolve ClusterIP DNS)

### DIFF
--- a/helm/node-doctor/templates/configmap.yaml
+++ b/helm/node-doctor/templates/configmap.yaml
@@ -177,6 +177,30 @@ data:
             checkInterfaces: true
       {{- end }}
 
+      # DNS Health Monitor — cluster-domain check DISABLED (clusterDomains: []).
+      # node-doctor runs hostNetwork; from the host netns the kube-dns ClusterIP does
+      # NOT resolve cluster records (Cilium host-netns->ClusterIP), so ANY cluster
+      # domain (cluster.local OR a custom cluster-domain) NXDOMAINs even though pods
+      # resolve fine — a structural false positive that spammed ClusterDNSResolutionFailed
+      # fleet-wide and got a version rolled back (cluster-services #19529). Without this
+      # explicit entry, ApplyDefaultMonitors adds a dns-health with the cluster.local
+      # default and the false positives return. External-domain resolution DOES work from
+      # hostNetwork and is retained as the node DNS signal.
+      - name: dns-health
+        type: network-dns-check
+        enabled: true
+        interval: 30s
+        timeout: 10s
+        config:
+          clusterDomains: []
+          externalDomains:
+            - google.com
+            - cloudflare.com
+          latencyThreshold: 1s
+          checkNameservers: true
+          failureCountThreshold: 3
+          enableNameserverChecks: true
+
     exporters:
       kubernetes:
         enabled: {{ .Values.exporters.kubernetes.enabled }}


### PR DESCRIPTION
Fixes fleet-wide `ClusterDNSResolutionFailed` false positives (cluster-services #19529).

## Problem
The chart ships **no `dns-health` monitor**, so node-doctor auto-adds one with the code default `clusterDomains: ["kubernetes.default.svc.cluster.local"]`. On any real deployment that is a **structural false positive**:
- node-doctor runs `hostNetwork: true`. From the host netns, the kube-dns **ClusterIP** does **not** resolve cluster records (Cilium host-netns→ClusterIP / socketLB not covering host traffic). Verified: from a hostNetwork pod, `kubernetes.default.svc.<domain>` NXDOMAINs for the default `cluster.local` **and** the real custom cluster-domain **and** the trailing-dot FQDN — while a normal pod resolves it fine.
- Result: `ClusterDNSResolutionFailed` / `NodeDoctorClusterDNSDown` / `NodeDoctorNetworkDegraded` fire on **every node**, and (observed) a node-doctor release was rolled back because of the noise — masking the trivial cause.

## Fix
Add an explicit `dns-health` monitor with `clusterDomains: []` (cluster-domain check disabled — it cannot work from a hostNetwork agent) and keep `externalDomains` (google/cloudflare **do** resolve from hostNetwork via CoreDNS forward) as the real node DNS signal. The explicit entry (name `dns-health`) also prevents `ApplyDefaultMonitors` from re-adding the `cluster.local` default.

`helm template` renders valid config (dns-health present, clusterDomains []); `helm lint` clean. Verified live on a1-ops-prd: the false-positive events stopped fleet-wide.

Follow-ups (separate): node-doctor could auto-derive the cluster domain from resolv.conf and/or run the cluster-DNS probe from a pod-network sidecar; and conditions set by a now-disabled check are not cleared (stale-condition lifecycle).