### PR TITLE
fix(health): unix-socket + exec health probes (a1pinode01 hostPort fix) + ipv6 chart nil-pointer

### DIFF
--- a/cmd/node-doctor/healthcheck_test.go
+++ b/cmd/node-doctor/healthcheck_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/supporttools/node-doctor/pkg/health"
+)
+
+// TestRunHealthCheck exercises the exec-probe health check against a real health
+// server unix socket. This is the code path the Kubernetes exec probes invoke, and
+// the reason a1pinode01-class hostPort-8080 conflicts no longer crashloop the pod.
+func TestRunHealthCheck(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "health.sock")
+	srv, err := health.NewServer(&health.Config{
+		Enabled:    true,
+		Port:       0, // ephemeral TCP, no conflict
+		SocketPath: sockPath,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = srv.Stop() }()
+
+	// Liveness (/healthz) should be OK immediately.
+	if rc := runHealthCheck(sockPath, "/healthz"); rc != 0 {
+		t.Errorf("runHealthCheck(/healthz) = %d, want 0", rc)
+	}
+
+	// Readiness (/ready) is 503 (exit 1) until a status/ready flag is set.
+	if rc := runHealthCheck(sockPath, "/ready"); rc != 1 {
+		t.Errorf("runHealthCheck(/ready) before ready = %d, want 1", rc)
+	}
+	srv.SetReady(true)
+	if rc := runHealthCheck(sockPath, "/ready"); rc != 0 {
+		t.Errorf("runHealthCheck(/ready) after ready = %d, want 0", rc)
+	}
+
+	// A missing socket must fail (exit 1), not hang or panic.
+	if rc := runHealthCheck(filepath.Join(t.TempDir(), "nope.sock"), "/healthz"); rc != 1 {
+		t.Errorf("runHealthCheck(missing socket) = %d, want 1", rc)
+	}
+}

--- a/cmd/node-doctor/main.go
+++ b/cmd/node-doctor/main.go
@@ -64,8 +64,15 @@ func runHealthCheck(socketPath, probePath string) int {
 			},
 		},
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
 	// Host is ignored for unix sockets but must be a valid URL authority.
-	resp, err := client.Get("http://localhost" + probePath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost"+probePath, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "healthcheck build request failed: %v\n", err)
+		return 1
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "healthcheck %s via %s failed: %v\n", probePath, socketPath, err)
 		return 1
@@ -102,19 +109,19 @@ func (e *noopExporter) Stop() error {
 func main() {
 	// Parse command line flags
 	var (
-		configFile      = flag.String("config", "", "Path to configuration file")
-		version         = flag.Bool("version", false, "Show version information")
-		validateConfig  = flag.Bool("validate-config", false, "Validate configuration and exit")
-		dumpConfig      = flag.Bool("dump-config", false, "Dump effective configuration and exit")
-		listMonitors    = flag.Bool("list-monitors", false, "List available monitor types and exit")
-		debug           = flag.Bool("debug", false, "Enable debug logging")
-		dryRun          = flag.Bool("dry-run", false, "Enable dry-run mode (no actual remediation)")
-		logLevel        = flag.String("log-level", "", "Override log level (debug, info, warn, error)")
-		logFormat       = flag.String("log-format", "", "Override log format (json, text)")
-		enableProfiling = flag.Bool("enable-profiling", false, "Enable pprof profiling server")
-		profilingPort   = flag.Int("profiling-port", 6060, "Port for pprof profiling server")
-		healthSocket    = flag.String("health-socket", defaultHealthSocket, "Path to the health server unix domain socket")
-		healthCheck     = flag.Bool("healthcheck", false, "Probe liveness (/healthz) via the health unix socket and exit 0 (ok) or 1 (fail). Used by Kubernetes exec probes.")
+		configFile       = flag.String("config", "", "Path to configuration file")
+		version          = flag.Bool("version", false, "Show version information")
+		validateConfig   = flag.Bool("validate-config", false, "Validate configuration and exit")
+		dumpConfig       = flag.Bool("dump-config", false, "Dump effective configuration and exit")
+		listMonitors     = flag.Bool("list-monitors", false, "List available monitor types and exit")
+		debug            = flag.Bool("debug", false, "Enable debug logging")
+		dryRun           = flag.Bool("dry-run", false, "Enable dry-run mode (no actual remediation)")
+		logLevel         = flag.String("log-level", "", "Override log level (debug, info, warn, error)")
+		logFormat        = flag.String("log-format", "", "Override log format (json, text)")
+		enableProfiling  = flag.Bool("enable-profiling", false, "Enable pprof profiling server")
+		profilingPort    = flag.Int("profiling-port", 6060, "Port for pprof profiling server")
+		healthSocket     = flag.String("health-socket", defaultHealthSocket, "Path to the health server unix domain socket")
+		healthCheck      = flag.Bool("healthcheck", false, "Probe liveness (/healthz) via the health unix socket and exit 0 (ok) or 1 (fail). Used by Kubernetes exec probes.")
 		healthCheckReady = flag.Bool("healthcheck-ready", false, "Probe readiness (/ready) via the health unix socket and exit 0/1. Used by the Kubernetes readiness exec probe.")
 	)
 	flag.Parse()

--- a/cmd/node-doctor/main.go
+++ b/cmd/node-doctor/main.go
@@ -7,6 +7,8 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"runtime"
@@ -43,6 +45,39 @@ var (
 	BuildTime = "unknown"
 )
 
+// defaultHealthSocket is the per-pod unix domain socket the health server listens
+// on and the `-healthcheck` exec probe dials. It lives on an in-pod (empty-dir)
+// mount so it can never collide with a foreign host process, unlike hostPort 8080.
+const defaultHealthSocket = "/var/run/node-doctor/health.sock"
+
+// runHealthCheck connects to the health server's unix socket, issues a GET for
+// probePath (/healthz or /ready), and returns a process exit code: 0 when the
+// endpoint returns 2xx, 1 otherwise. It is intentionally dependency-free and
+// fast (short timeout) because the kubelet invokes it as an exec probe.
+func runHealthCheck(socketPath, probePath string) int {
+	client := &http.Client{
+		Timeout: 3 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", socketPath)
+			},
+		},
+	}
+	// Host is ignored for unix sockets but must be a valid URL authority.
+	resp, err := client.Get("http://localhost" + probePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "healthcheck %s via %s failed: %v\n", probePath, socketPath, err)
+		return 1
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return 0
+	}
+	fmt.Fprintf(os.Stderr, "healthcheck %s returned HTTP %d\n", probePath, resp.StatusCode)
+	return 1
+}
+
 // noopExporter is a no-op implementation of types.Exporter for when no real exporters are configured
 type noopExporter struct{}
 
@@ -78,8 +113,24 @@ func main() {
 		logFormat       = flag.String("log-format", "", "Override log format (json, text)")
 		enableProfiling = flag.Bool("enable-profiling", false, "Enable pprof profiling server")
 		profilingPort   = flag.Int("profiling-port", 6060, "Port for pprof profiling server")
+		healthSocket    = flag.String("health-socket", defaultHealthSocket, "Path to the health server unix domain socket")
+		healthCheck     = flag.Bool("healthcheck", false, "Probe liveness (/healthz) via the health unix socket and exit 0 (ok) or 1 (fail). Used by Kubernetes exec probes.")
+		healthCheckReady = flag.Bool("healthcheck-ready", false, "Probe readiness (/ready) via the health unix socket and exit 0/1. Used by the Kubernetes readiness exec probe.")
 	)
 	flag.Parse()
+
+	// Health-check subcommand: connect to the per-pod unix socket and exit with a
+	// probe-friendly status code. This runs as a separate short-lived process
+	// invoked by the kubelet exec probe; it must NOT load config or start monitors.
+	// Using the unix socket (not TCP :8080) makes probes immune to a foreign
+	// process squatting the hostPort on hostNetwork nodes (see pkg/health).
+	if *healthCheck || *healthCheckReady {
+		path := "/healthz"
+		if *healthCheckReady {
+			path = "/ready"
+		}
+		os.Exit(runHealthCheck(*healthSocket, path))
+	}
 
 	if *version {
 		fmt.Printf("Node Doctor %s\n", Version)
@@ -273,7 +324,7 @@ func main() {
 	if remediatorRegistry != nil {
 		historyProvider = &remediationHistoryAdapter{registry: remediatorRegistry}
 	}
-	exporters, exporterInterfaces, promExporter, err := createExporters(ctx, config, historyProvider)
+	exporters, exporterInterfaces, promExporter, err := createExporters(ctx, config, historyProvider, *healthSocket)
 	if err != nil {
 		log.Fatalf("Failed to create exporters: %v", err)
 	}
@@ -399,7 +450,7 @@ func (a *remediationHistoryAdapter) GetHistory(limit int) interface{} {
 // createExporters creates and configures all exporters from the configuration.
 // remediationProvider is optional; when non-nil it is wired to the health server
 // before Start() so /remediation/history is available immediately on first request.
-func createExporters(ctx context.Context, config *types.NodeDoctorConfig, remediationProvider health.RemediationHistoryProvider) ([]ExporterLifecycle, []types.Exporter, *prometheusexporter.PrometheusExporter, error) {
+func createExporters(ctx context.Context, config *types.NodeDoctorConfig, remediationProvider health.RemediationHistoryProvider, healthSocketPath string) ([]ExporterLifecycle, []types.Exporter, *prometheusexporter.PrometheusExporter, error) {
 	var exporters []ExporterLifecycle
 	var exporterInterfaces []types.Exporter
 	// promExporterTyped keeps a typed reference to the Prometheus exporter (if one
@@ -419,8 +470,12 @@ func createExporters(ctx context.Context, config *types.NodeDoctorConfig, remedi
 		Enabled: true,
 		// "::" binds dual-stack (IPv4 + IPv6) with graceful fallback to
 		// "0.0.0.0" when IPv6 is disabled on the node (handled in Start()).
-		BindAddress:  "::",
-		Port:         8080,
+		BindAddress: "::",
+		Port:        8080,
+		// Also serve on the per-pod unix socket so Kubernetes exec probes
+		// (-healthcheck) reach node-doctor even when a foreign process owns
+		// hostPort 8080 on a hostNetwork node.
+		SocketPath:   healthSocketPath,
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
 	})

--- a/cmd/node-doctor/main_additional_test.go
+++ b/cmd/node-doctor/main_additional_test.go
@@ -157,7 +157,7 @@ func TestCreateExporters_Current(t *testing.T) {
 			},
 		}
 
-		exporters, interfaces, _, err := createExporters(ctx, config, nil)
+		exporters, interfaces, _, err := createExporters(ctx, config, nil, "")
 		if err != nil {
 			t.Errorf("createExporters() error = %v, want nil", err)
 		}
@@ -198,7 +198,7 @@ func TestCreateExporters_Current(t *testing.T) {
 			},
 		}
 
-		exporters, _, _, err := createExporters(ctx, config, nil)
+		exporters, _, _, err := createExporters(ctx, config, nil, "")
 		if err != nil {
 			t.Errorf("createExporters() error = %v, want nil", err)
 		}
@@ -348,7 +348,7 @@ func TestCreateExporters_HTTPExporterEnabled(t *testing.T) {
 		},
 	}
 
-	exporters, interfaces, _, err := createExporters(ctx, config, nil)
+	exporters, interfaces, _, err := createExporters(ctx, config, nil, "")
 	if err != nil {
 		t.Errorf("createExporters() error = %v, want nil", err)
 	}
@@ -391,7 +391,7 @@ func TestCreateExporters_PrometheusExporterEnabled(t *testing.T) {
 		},
 	}
 
-	exporters, interfaces, _, err := createExporters(ctx, config, nil)
+	exporters, interfaces, _, err := createExporters(ctx, config, nil, "")
 	if err != nil {
 		t.Errorf("createExporters() error = %v, want nil", err)
 	}
@@ -435,7 +435,7 @@ func TestCreateExporters_KubernetesExporterEnabled(t *testing.T) {
 
 	// This should not panic even without valid kubeconfig
 	// It will log a warning but continue
-	exporters, interfaces, _, err := createExporters(ctx, config, nil)
+	exporters, interfaces, _, err := createExporters(ctx, config, nil, "")
 	if err != nil {
 		t.Errorf("createExporters() error = %v, want nil", err)
 	}
@@ -484,7 +484,7 @@ func TestCreateExporters_AllExportersEnabled(t *testing.T) {
 		},
 	}
 
-	exporters, interfaces, _, err := createExporters(ctx, config, nil)
+	exporters, interfaces, _, err := createExporters(ctx, config, nil, "")
 	if err != nil {
 		t.Errorf("createExporters() error = %v, want nil", err)
 	}
@@ -524,7 +524,7 @@ func TestCreateExporters_HealthServerCreation(t *testing.T) {
 		},
 	}
 
-	exporters, interfaces, _, err := createExporters(ctx, config, nil)
+	exporters, interfaces, _, err := createExporters(ctx, config, nil, "")
 	if err != nil {
 		t.Errorf("createExporters() error = %v, want nil", err)
 	}
@@ -558,7 +558,7 @@ func TestCreateExporters_NoopFallbackVerification(t *testing.T) {
 		},
 	}
 
-	exporters, interfaces, _, err := createExporters(ctx, config, nil)
+	exporters, interfaces, _, err := createExporters(ctx, config, nil, "")
 	if err != nil {
 		t.Errorf("createExporters() error = %v, want nil", err)
 	}
@@ -629,7 +629,7 @@ func TestCreateExporters_HTTPExporterWithValidConfig(t *testing.T) {
 		},
 	}
 
-	exporters, interfaces, _, err := createExporters(ctx, config, nil)
+	exporters, interfaces, _, err := createExporters(ctx, config, nil, "")
 	if err != nil {
 		t.Errorf("createExporters() error = %v, want nil", err)
 	}
@@ -677,7 +677,7 @@ func TestCreateExporters_KubernetesExporterWithValidConfig(t *testing.T) {
 	}
 
 	// This will fail without kubeconfig but should exercise the validation path
-	exporters, interfaces, _, err := createExporters(ctx, config, nil)
+	exporters, interfaces, _, err := createExporters(ctx, config, nil, "")
 	if err != nil {
 		t.Errorf("createExporters() error = %v, want nil", err)
 	}
@@ -742,7 +742,7 @@ func TestCreateExporters_MultipleExportersWithValidConfig(t *testing.T) {
 		},
 	}
 
-	exporters, interfaces, _, err := createExporters(ctx, config, nil)
+	exporters, interfaces, _, err := createExporters(ctx, config, nil, "")
 	if err != nil {
 		t.Errorf("createExporters() error = %v, want nil", err)
 	}

--- a/cmd/node-doctor/main_comprehensive_test.go
+++ b/cmd/node-doctor/main_comprehensive_test.go
@@ -267,7 +267,7 @@ func TestCreateExporters_TableDriven(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			exporters, interfaces, _, err := createExporters(ctx, tt.config, nil)
+			exporters, interfaces, _, err := createExporters(ctx, tt.config, nil, "")
 			if err != nil {
 				t.Errorf("createExporters() error = %v", err)
 				return

--- a/helm/node-doctor/templates/daemonset.yaml
+++ b/helm/node-doctor/templates/daemonset.yaml
@@ -117,10 +117,16 @@ spec:
 
         {{- if .Values.probes.liveness.enabled }}
         livenessProbe:
+          {{- if .Values.probes.liveness.exec }}
+          exec:
+            command:
+              {{- toYaml .Values.probes.liveness.exec.command | nindent 14 }}
+          {{- else }}
           httpGet:
             path: {{ .Values.probes.liveness.httpGet.path }}
             port: {{ .Values.probes.liveness.httpGet.port }}
             scheme: HTTP
+          {{- end }}
           initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
           timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
@@ -130,10 +136,16 @@ spec:
 
         {{- if .Values.probes.readiness.enabled }}
         readinessProbe:
+          {{- if .Values.probes.readiness.exec }}
+          exec:
+            command:
+              {{- toYaml .Values.probes.readiness.exec.command | nindent 14 }}
+          {{- else }}
           httpGet:
             path: {{ .Values.probes.readiness.httpGet.path }}
             port: {{ .Values.probes.readiness.httpGet.port }}
             scheme: HTTP
+          {{- end }}
           initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
           timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
@@ -143,10 +155,16 @@ spec:
 
         {{- if .Values.probes.startup.enabled }}
         startupProbe:
+          {{- if .Values.probes.startup.exec }}
+          exec:
+            command:
+              {{- toYaml .Values.probes.startup.exec.command | nindent 14 }}
+          {{- else }}
           httpGet:
             path: {{ .Values.probes.startup.httpGet.path }}
             port: {{ .Values.probes.startup.httpGet.port }}
             scheme: HTTP
+          {{- end }}
           initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.startup.periodSeconds }}
           timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
@@ -159,6 +177,12 @@ spec:
         - name: config
           mountPath: /etc/node-doctor
           readOnly: true
+
+        # Health server unix socket (per-pod, in-memory). The exec health probes
+        # dial /var/run/node-doctor/health.sock, so they never depend on winning
+        # hostPort 8080 (which a foreign host process can own on a hostNetwork node).
+        - name: health-runtime
+          mountPath: /var/run/node-doctor
 
         # Host filesystem mounts
         - name: host-root
@@ -221,6 +245,13 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
+
+      # Per-pod in-memory dir holding the health server unix socket. Emptied on
+      # every pod start, so a stale socket from a crashed process never persists.
+      - name: health-runtime
+        emptyDir:
+          medium: Memory
+          sizeLimit: 1Mi
 
       # Host path volumes
       - name: host-root

--- a/helm/node-doctor/templates/prometheusrule.yaml
+++ b/helm/node-doctor/templates/prometheusrule.yaml
@@ -217,7 +217,7 @@ spec:
           annotations:
             summary: "High API server latency on {{`{{ $labels.node }}`}}"
             description: "Node {{`{{ $labels.node }}`}} is experiencing high latency communicating with the API server."
-        {{- if .Values.prometheusRule.warning.ipv6Misconfigured.enabled }}
+        {{- if and (hasKey .Values.prometheusRule.warning "ipv6Misconfigured") .Values.prometheusRule.warning.ipv6Misconfigured.enabled }}
 
         - alert: NodeDoctorIPv6Misconfigured
           # Covers all IPv6-specific conditions (IPv6SysctlMisconfigured,

--- a/helm/node-doctor/values.yaml.template
+++ b/helm/node-doctor/values.yaml.template
@@ -193,6 +193,18 @@ prometheusRule:
       thresholdPercent: 90
     apiServerLatencyHigh:
       for: 10m
+    # Consolidated IPv6 alert (fires on any condition_type=~"IPv6.*").
+    # Disabled by default: on mixed IPv4/dual-stack fleets the IPv6 monitors
+    # raise benign warnings on IPv4-only nodes, which would page here. Opt in
+    # (enabled: true) once IPv6 condition semantics are validated for your fleet.
+    # NOTE: this key MUST exist even when disabled — templates/prometheusrule.yaml
+    # references .ipv6Misconfigured.enabled/.for/.labels/.annotations, and a missing
+    # block makes `helm upgrade` nil-pointer whenever prometheusRule.enabled=true.
+    ipv6Misconfigured:
+      enabled: false
+      for: 10m
+      labels: {}
+      annotations: {}
 
   # Informational alerts - for awareness
   info:
@@ -203,13 +215,18 @@ prometheusRule:
     noMetrics:
       for: 10m
 
-# Health probe configuration
+# Health probe configuration.
+# Probes default to `exec` running the binary's built-in health check, which talks
+# to a per-pod unix socket (/var/run/node-doctor/health.sock) instead of TCP :8080.
+# Because node-doctor runs with hostNetwork:true, a foreign host process (e.g. an
+# IP-float/VIP daemon on hostPort 8080) can answer an httpGet probe with a 404 and
+# crashloop the pod; the unix socket lives in the pod and cannot collide.
+# To revert to HTTP probes, replace the `exec:` block with `httpGet: {path, port}`.
 probes:
   liveness:
     enabled: true
-    httpGet:
-      path: /healthz
-      port: 8080
+    exec:
+      command: ["/usr/local/bin/node-doctor", "-healthcheck"]
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
@@ -217,9 +234,8 @@ probes:
     successThreshold: 1
   readiness:
     enabled: true
-    httpGet:
-      path: /ready
-      port: 8080
+    exec:
+      command: ["/usr/local/bin/node-doctor", "-healthcheck-ready"]
     initialDelaySeconds: 10
     periodSeconds: 5
     timeoutSeconds: 3
@@ -227,9 +243,8 @@ probes:
     successThreshold: 1
   startup:
     enabled: true
-    httpGet:
-      path: /healthz
-      port: 8080
+    exec:
+      command: ["/usr/local/bin/node-doctor", "-healthcheck"]
     initialDelaySeconds: 10
     periodSeconds: 5
     timeoutSeconds: 3

--- a/pkg/health/server.go
+++ b/pkg/health/server.go
@@ -9,6 +9,8 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"time"
@@ -20,6 +22,9 @@ import (
 type Server struct {
 	config             *Config
 	httpServer         *http.Server
+	tcpListener        net.Listener
+	unixListener       net.Listener
+	socketPath         string
 	mu                 sync.RWMutex
 	started            bool
 	healthy            bool
@@ -43,6 +48,17 @@ type Config struct {
 
 	// Port is the port to listen on (default: 8080)
 	Port int
+
+	// SocketPath, when non-empty, makes the server ALSO serve the same health
+	// endpoints on a per-pod unix domain socket. This is the reliable channel for
+	// Kubernetes probes: because node-doctor runs with hostNetwork:true, the TCP
+	// Port can be squatted by a foreign host process (e.g. an IP-float/VIP daemon
+	// on hostPort 8080), which makes an httpGet probe fail with a 404 from the
+	// squatter and crashloop the pod. A unix socket lives in the pod's own
+	// (empty-dir) filesystem and cannot collide, so the exec `-healthcheck` probe
+	// always reaches node-doctor's real health server. The TCP listener is still
+	// served best-effort for external monitoring/load-balancers.
+	SocketPath string
 
 	// ReadTimeout for HTTP requests
 	ReadTimeout time.Duration
@@ -160,6 +176,7 @@ func NewServer(config *Config) (*Server, error) {
 
 	server := &Server{
 		config:       config,
+		socketPath:   config.SocketPath,
 		started:      false,
 		healthy:      true,
 		ready:        false,
@@ -168,6 +185,27 @@ func NewServer(config *Config) (*Server, error) {
 	}
 
 	return server, nil
+}
+
+// listenUnix creates a unix domain socket listener at path, ensuring the parent
+// directory exists and removing any stale socket left by a previous (crashed)
+// process. The socket is chmod 0660 so co-located sidecars/probes in the same
+// pod can reach it while it stays off the network entirely.
+func listenUnix(path string) (net.Listener, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create socket dir: %w", err)
+	}
+	// A leftover socket file from a prior crash would make Listen fail with
+	// "address already in use"; remove it first (it is a per-pod path we own).
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("remove stale socket %s: %w", path, err)
+	}
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, err
+	}
+	_ = os.Chmod(path, 0o660)
+	return ln, nil
 }
 
 // Start starts the health server.
@@ -186,33 +224,65 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("/status", s.handleStatus)
 	mux.HandleFunc("/remediation/history", s.handleRemediationHistory)
 
-	// Eagerly bind the listener so bind failures propagate synchronously.
-	// Using net.Listen + Serve instead of ListenAndServe avoids the race where
-	// a goroutine fails silently after Start() returns success.
-	// listenWithFallback uses net.JoinHostPort (correct IPv6 bracketing) and
-	// retries on "0.0.0.0" when a dual-stack/IPv6 bind fails.
-	ln, err := listenWithFallback(s.config.BindAddress, s.config.Port)
-	if err != nil {
-		return fmt.Errorf("health server failed to bind: %w", err)
-	}
-
+	// A single *http.Server can Serve() multiple listeners concurrently; Shutdown
+	// closes all of them. We serve on two:
+	//   1. TCP (best-effort) — for external monitoring/load-balancers. On a
+	//      hostNetwork node this can fail if a foreign process owns the port; that
+	//      is NON-FATAL (we log and continue) because it must not crashloop the pod.
+	//   2. Unix socket (reliable) — the per-pod channel the exec `-healthcheck`
+	//      probe uses. This is the one that must come up for the pod to be usable.
 	s.httpServer = &http.Server{
-		Addr:         ln.Addr().String(),
 		Handler:      mux,
 		ReadTimeout:  s.config.ReadTimeout,
 		WriteTimeout: s.config.WriteTimeout,
 	}
 
-	// Start HTTP server using the already-bound listener
-	go func() {
-		log.Printf("[INFO] Starting health server on %s", ln.Addr())
-		if err := s.httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
-			log.Printf("[ERROR] Health server failed: %v", err)
+	var served bool
+
+	// 1. TCP listener (best-effort). listenWithFallback uses net.JoinHostPort
+	// (correct IPv6 bracketing) and retries on "0.0.0.0" when a dual-stack bind fails.
+	if tcpLn, err := listenWithFallback(s.config.BindAddress, s.config.Port); err != nil {
+		// Non-fatal: a foreign process squatting on the hostPort (common cause:
+		// address already in use) must not take node-doctor down. Probes use the
+		// unix socket; only external HTTP health on this node is unavailable.
+		log.Printf("[WARN] health server TCP bind on port %d failed (%v); continuing without external HTTP health on this node — Kubernetes probes use the unix socket", s.config.Port, err)
+	} else {
+		s.tcpListener = tcpLn
+		// Record the bound TCP address. http.Server.Serve ignores Addr, but callers
+		// (and tests) read it to discover the actual host:port, especially with an
+		// ephemeral Port: 0.
+		s.httpServer.Addr = tcpLn.Addr().String()
+		go func() {
+			log.Printf("[INFO] Health server (TCP) serving on %s", tcpLn.Addr())
+			if err := s.httpServer.Serve(tcpLn); err != nil && err != http.ErrServerClosed {
+				log.Printf("[ERROR] Health server (TCP) failed: %v", err)
+			}
+		}()
+		served = true
+	}
+
+	// 2. Unix socket listener (reliable, per-pod). Used by exec probes.
+	if s.socketPath != "" {
+		if unixLn, err := listenUnix(s.socketPath); err != nil {
+			log.Printf("[WARN] health server unix socket bind at %s failed: %v", s.socketPath, err)
+		} else {
+			s.unixListener = unixLn
+			go func() {
+				log.Printf("[INFO] Health server (unix) serving on %s", s.socketPath)
+				if err := s.httpServer.Serve(unixLn); err != nil && err != http.ErrServerClosed {
+					log.Printf("[ERROR] Health server (unix) failed: %v", err)
+				}
+			}()
+			served = true
 		}
-	}()
+	}
+
+	if !served {
+		return fmt.Errorf("health server failed to bind any listener (tcp port %d and unix socket %q both failed)", s.config.Port, s.socketPath)
+	}
 
 	s.started = true
-	log.Printf("[INFO] Health server started successfully on %s", ln.Addr())
+	log.Printf("[INFO] Health server started successfully (tcp=%v unix=%v)", s.tcpListener != nil, s.unixListener != nil)
 
 	return nil
 }
@@ -240,6 +310,14 @@ func (s *Server) Stop() error {
 
 	if err := httpServer.Shutdown(ctx); err != nil {
 		return fmt.Errorf("failed to shutdown health server: %w", err)
+	}
+
+	// Remove the unix socket file so a subsequent start doesn't trip over a stale
+	// path (listenUnix also removes it, but clean up eagerly on graceful stop).
+	if s.socketPath != "" {
+		if err := os.Remove(s.socketPath); err != nil && !os.IsNotExist(err) {
+			log.Printf("[WARN] failed to remove health socket %s: %v", s.socketPath, err)
+		}
 	}
 
 	log.Printf("[INFO] Health server stopped")

--- a/pkg/health/server_test.go
+++ b/pkg/health/server_test.go
@@ -6,10 +6,106 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 )
+
+// getOverUnixSocket issues an HTTP GET for path against a health server listening
+// on a unix domain socket, returning the status code.
+func getOverUnixSocket(t *testing.T, socketPath, path string) int {
+	t.Helper()
+	client := &http.Client{
+		Timeout: 3 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", socketPath)
+			},
+		},
+	}
+	resp, err := client.Get("http://localhost" + path)
+	if err != nil {
+		t.Fatalf("GET %s over unix socket %s: %v", path, socketPath, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode
+}
+
+// TestServer_UnixSocket verifies the health endpoints are served over the per-pod
+// unix socket and that the socket file is cleaned up on Stop.
+func TestServer_UnixSocket(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "health.sock")
+	srv, err := NewServer(&Config{
+		Enabled:    true,
+		Port:       0, // ephemeral TCP — no conflict
+		SocketPath: sockPath,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// /healthz should be reachable over the socket and report healthy (200).
+	if code := getOverUnixSocket(t, sockPath, "/healthz"); code != http.StatusOK {
+		t.Errorf("/healthz over socket = %d, want 200", code)
+	}
+	// /ready is 503 until a status arrives; after UpdateStatus it should be 200.
+	if code := getOverUnixSocket(t, sockPath, "/ready"); code != http.StatusServiceUnavailable {
+		t.Errorf("/ready before status = %d, want 503", code)
+	}
+	srv.SetReady(true)
+	if code := getOverUnixSocket(t, sockPath, "/ready"); code != http.StatusOK {
+		t.Errorf("/ready after ready=true = %d, want 200", code)
+	}
+	if err := srv.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if _, err := os.Stat(sockPath); !os.IsNotExist(err) {
+		t.Errorf("socket file %s should be removed after Stop, stat err=%v", sockPath, err)
+	}
+}
+
+// TestServer_TCPConflictNonFatal verifies that when the TCP port is already taken
+// (the a1pinode01 / go-ip-float hostPort-8080 scenario), Start still succeeds via
+// the unix socket rather than crashlooping the pod.
+func TestServer_TCPConflictNonFatal(t *testing.T) {
+	// Occupy a TCP port to simulate a foreign process squatting the hostPort.
+	squatter, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("occupy port: %v", err)
+	}
+	defer func() { _ = squatter.Close() }()
+	occupiedPort := squatter.Addr().(*net.TCPAddr).Port
+
+	sockPath := filepath.Join(t.TempDir(), "health.sock")
+	srv, err := NewServer(&Config{
+		Enabled:     true,
+		BindAddress: "127.0.0.1", // non-dual-stack: bind fails outright on the taken port
+		Port:        occupiedPort,
+		SocketPath:  sockPath,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	// Must NOT error even though the TCP bind conflicts — the socket carries probes.
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("Start should be non-fatal on TCP conflict, got: %v", err)
+	}
+	if srv.tcpListener != nil {
+		t.Error("expected TCP listener to be nil after bind conflict")
+	}
+	if srv.unixListener == nil {
+		t.Fatal("expected unix listener to be up so probes work")
+	}
+	if code := getOverUnixSocket(t, sockPath, "/healthz"); code != http.StatusOK {
+		t.Errorf("/healthz over socket during TCP conflict = %d, want 200", code)
+	}
+	_ = srv.Stop()
+}
 
 // mockRemediationHistory is a mock implementation of RemediationHistoryProvider for testing.
 type mockRemediationHistory struct {


### PR DESCRIPTION
## Summary
Prod-hardening feature 1283. Two fixes:

**248/246 — a1pinode01 health-server hostPort conflict (make the fleet fully healthy)**
node-doctor runs `hostNetwork:true`; on a1pinode01 a foreign daemon (`go-ip-float`) owns hostPort 8080, so the health server can't bind, the squatter answers `:8080/healthz` with 404, and the kubelet crashloops the pod. Fix: the health server now also serves the same endpoints on a **per-pod unix socket** (`/var/run/node-doctor/health.sock`, tmpfs emptyDir), and the k8s liveness/readiness/startup probes switch to an **exec `-healthcheck`/`-healthcheck-ready`** subcommand that dials the socket. Probes no longer depend on winning hostPort 8080. TCP :8080 is still served best-effort for external monitoring; its bind failure is non-fatal.

**247 — chart nil-pointer**
`values.yaml.template` now defines `prometheusRule.warning.ipv6Misconfigured` (default **disabled** on mixed IPv4/dual-stack fleets), and `prometheusrule.yaml` guards the ref with `hasKey`. `helm upgrade --set prometheusRule.enabled=true` no longer nil-pointers.

## Tests
- `pkg/health`: unix-socket serving, **TCP-conflict-is-non-fatal** (the a1pinode01 scenario), socket cleanup on Stop.
- `cmd/node-doctor`: `runHealthCheck` exit codes (liveness/readiness/missing-socket).
- Chart render verified under `prometheusRule.enabled=true` (default-off, opt-in, and stale-partial-values).

## Deploy note
Chart publish to charts.support.tools 403s (known cross-repo token issue); roll is done from the locally-rendered chart. Probes change from httpGet to exec — will be canaried on one node before the full roll.

Tasks: #19596 (248), #19565 (246), #19588 (247)