### PR TITLE
fix(helm): ship overlay-test CPU limit via values.yaml.template + guard the generated-file trap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,29 @@ jobs:
       - name: Run golangci-lint
         run: golangci-lint run --timeout=5m
 
+  # Helm chart job - guards the generated-vs-template trap and lints the chart.
+  #
+  # release.yml deletes helm/node-doctor/{Chart,values}.yaml and re-renders them from
+  # the *.template files before packaging, so hand-edits to the committed copies never
+  # reach the published chart. That silently swallowed an overlay-test CPU-limit fix for
+  # six months (it was committed to values.yaml, not values.yaml.template). This job
+  # fails the build whenever the two diverge.
+  helm-chart:
+    name: Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Verify Chart.yaml/values.yaml match their templates
+        run: make helm-verify-generated
+
+      - name: Lint chart
+        run: helm lint ./helm/node-doctor
+
   # Test job - runs unit and integration tests
   test:
     name: Test
@@ -307,7 +330,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, test, build, security-gosec]
+    needs: [lint, test, build, security-gosec, helm-chart]
     if: always()
     steps:
       - name: Check job results
@@ -315,7 +338,8 @@ jobs:
           if [[ "${{ needs.lint.result }}" != "success" ]] || \
              [[ "${{ needs.test.result }}" != "success" ]] || \
              [[ "${{ needs.build.result }}" != "success" ]] || \
-             [[ "${{ needs.security-gosec.result }}" != "success" ]]; then
+             [[ "${{ needs.security-gosec.result }}" != "success" ]] || \
+             [[ "${{ needs.helm-chart.result }}" != "success" ]]; then
             echo "One or more CI jobs failed"
             exit 1
           fi

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@
 	test-net-icmp-integration \
 	lint fmt clean install-deps \
 	docker-build docker-push \
+	helm-lint helm-package helm-publish helm-generate helm-verify-generated \
 	coverage-check
 
 # ================================================================================================
@@ -393,7 +394,43 @@ push-all-images: push-node-doctor-image push-overlay-test-server-image
 # Helm Chart Targets
 # ================================================================================================
 
-helm-lint:
+# Chart.yaml and values.yaml are GENERATED from *.template — the release workflow
+# (.github/workflows/release.yml) deletes both and re-renders them with envsubst before
+# packaging, so the published chart NEVER contains hand-edits made directly to them.
+# Edit the .template files, then run `make helm-generate`. CI enforces this via
+# `make helm-verify-generated`.
+#
+# These placeholders stand in for the tag-derived values CI injects; they exist only so
+# the committed copies are byte-reproducible and diffable.
+HELM_PLACEHOLDER_CHART_VERSION := 1.0.0
+HELM_PLACEHOLDER_APP_VERSION   := v1.0.0
+HELM_PLACEHOLDER_IMAGE_TAG     := v1.0.0
+
+# Renders the templates the same way release.yml does (bare envsubst).
+define helm_render
+	CHART_VERSION="$(HELM_PLACEHOLDER_CHART_VERSION)" \
+	APP_VERSION="$(HELM_PLACEHOLDER_APP_VERSION)" \
+	IMAGE_TAG="$(HELM_PLACEHOLDER_IMAGE_TAG)" \
+	envsubst < helm/$(PROJECT_NAME)/$(1).template > $(2)
+endef
+
+helm-generate:
+	@$(call print_status,"Regenerating Chart.yaml and values.yaml from templates...")
+	@$(call helm_render,Chart.yaml,helm/$(PROJECT_NAME)/Chart.yaml)
+	@$(call helm_render,values.yaml,helm/$(PROJECT_NAME)/values.yaml)
+	@$(call print_success,"Chart files regenerated - commit them")
+
+helm-verify-generated:
+	@$(call print_status,"Checking Chart.yaml/values.yaml match their templates...")
+	@$(call helm_render,Chart.yaml,/tmp/node-doctor-Chart.rendered.yaml)
+	@$(call helm_render,values.yaml,/tmp/node-doctor-values.rendered.yaml)
+	@diff -u helm/$(PROJECT_NAME)/Chart.yaml /tmp/node-doctor-Chart.rendered.yaml || \
+		{ $(call print_error,"Chart.yaml drifted from Chart.yaml.template - run 'make helm-generate'"); exit 1; }
+	@diff -u helm/$(PROJECT_NAME)/values.yaml /tmp/node-doctor-values.rendered.yaml || \
+		{ $(call print_error,"values.yaml drifted from values.yaml.template - run 'make helm-generate'"); exit 1; }
+	@$(call print_success,"Chart files match their templates")
+
+helm-lint: helm-verify-generated
 	@$(call print_status,"Linting Helm chart...")
 	@helm lint ./helm/$(PROJECT_NAME)
 	@$(call print_success,"Helm lint passed")

--- a/deployment/prometheusrule.yaml
+++ b/deployment/prometheusrule.yaml
@@ -191,9 +191,14 @@ spec:
     # Informational alerts - for awareness
     - name: node-doctor-info
       rules:
+        # Do NOT use changes() here. node_doctor_monitor_uptime_seconds is a counter that
+        # increases at every scrape, so changes(...[5m]) evaluates to the scrape count and
+        # is permanently > 0 on every node — it fired fleet-wide forever and never once
+        # signalled a real restart. A low absolute uptime is the actual restart signal.
         - alert: NodeDoctorAgentRestarted
           expr: |
-            changes(node_doctor_monitor_uptime_seconds[5m]) > 0
+            node_doctor_monitor_uptime_seconds < 600
+          for: 0m
           labels:
             severity: info
             component: agent

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -5,6 +5,7 @@ This document describes the release process for Node Doctor, including versionin
 ## Table of Contents
 
 - [Release Overview](#release-overview)
+- [Which Helm chart files actually ship](#which-helm-chart-files-actually-ship)
 - [Version Numbering](#version-numbering)
 - [Release Types](#release-types)
 - [Creating a Release](#creating-a-release)
@@ -26,6 +27,55 @@ Node Doctor uses automated releases triggered by Git tags. When a tag matching `
 7. ✅ Updates Harbor registry with new version
 
 **Timeline**: Full release pipeline completes in ~10-15 minutes.
+
+## Which Helm chart files actually ship
+
+**`helm/node-doctor/values.yaml` and `helm/node-doctor/Chart.yaml` are generated artifacts.
+Never hand-edit them.**
+
+Before packaging, `.github/workflows/release.yml` deletes both and re-renders them from the
+`*.template` files:
+
+```bash
+rm -f helm/node-doctor/Chart.yaml helm/node-doctor/values.yaml
+envsubst < helm/node-doctor/Chart.yaml.template  > helm/node-doctor/Chart.yaml
+envsubst < helm/node-doctor/values.yaml.template > helm/node-doctor/values.yaml
+```
+
+So an edit made directly to `values.yaml` **never reaches the published chart**. It is not
+rejected and it produces no warning — it is simply discarded at package time. `.helmignore`
+excludes the `*.template` files, so the resulting tarball looks entirely normal.
+
+This is not theoretical. Commit `8d555e8` (2026-02-11) raised the overlay-test CPU limit from
+10m to 100m to stop CFS throttling that was inflating probe latency to 300-500ms. It edited
+`values.yaml`. The change shipped in name only and the cluster ran the throttled 10m limit for
+six months, while the *other* half of the same commit — which touched
+`templates/configmap.yaml` — went live immediately.
+
+**The rule that follows:** everything under `templates/` is packaged verbatim and behaves as
+you expect. Only `values.yaml` and `Chart.yaml` are regenerated. A chart change's fate depends
+entirely on which of those two groups it lands in.
+
+### Workflow
+
+1. Edit `helm/node-doctor/values.yaml.template` (or `Chart.yaml.template`).
+2. Run `make helm-generate` to re-render the committed copies.
+3. Commit both the template and the generated file.
+
+`make helm-verify-generated` re-renders and diffs; it runs in CI as the `Helm Chart` job and
+fails the build on any drift. `make helm-lint` depends on it, so a local lint catches this too.
+
+### Verifying a chart change actually shipped
+
+Checking the live object is not sufficient — it cannot distinguish "the chart is stale" from
+"the chart is fine but the object drifted". Check what Helm rendered:
+
+```bash
+helm -n node-doctor get manifest node-doctor | grep -A6 'Minimal resources'
+```
+
+If the rendered manifest still shows the old value, the published chart is stale regardless of
+what `kubectl get ds` reports.
 
 ## Version Numbering
 

--- a/helm/node-doctor/templates/overlay-test-daemonset.yaml
+++ b/helm/node-doctor/templates/overlay-test-daemonset.yaml
@@ -88,13 +88,15 @@ spec:
             drop:
               - ALL
 
-        # Minimal resources
+        # Minimal resources. The CPU fallbacks must stay at 5m/100m: a 10m limit
+        # CFS-throttles this pod ~90% of periods and inflates its own probe latency
+        # to 300-500ms, which surfaces as false NetworkDegraded/HighPeerLatency.
         resources:
           requests:
-            cpu: {{ .Values.overlayTest.resources.requests.cpu | default "1m" }}
+            cpu: {{ .Values.overlayTest.resources.requests.cpu | default "5m" }}
             memory: {{ .Values.overlayTest.resources.requests.memory | default "8Mi" }}
           limits:
-            cpu: {{ .Values.overlayTest.resources.limits.cpu | default "10m" }}
+            cpu: {{ .Values.overlayTest.resources.limits.cpu | default "100m" }}
             memory: {{ .Values.overlayTest.resources.limits.memory | default "16Mi" }}
 
         # HTTP liveness probe on /healthz

--- a/helm/node-doctor/templates/prometheusrule.yaml
+++ b/helm/node-doctor/templates/prometheusrule.yaml
@@ -248,9 +248,14 @@ spec:
     # Informational alerts - for awareness
     - name: {{ include "node-doctor.fullname" . }}-info
       rules:
+        # Do NOT use changes() here. node_doctor_monitor_uptime_seconds is a counter that
+        # increases at every scrape, so changes(...[5m]) evaluates to the scrape count and
+        # is permanently > 0 on every node — it fired fleet-wide forever and never once
+        # signalled a real restart. A low absolute uptime is the actual restart signal.
         - alert: NodeDoctorAgentRestarted
           expr: |
-            changes(node_doctor_monitor_uptime_seconds[5m]) > 0
+            node_doctor_monitor_uptime_seconds < 600
+          for: 0m
           labels:
             severity: info
             component: agent

--- a/helm/node-doctor/values.yaml
+++ b/helm/node-doctor/values.yaml
@@ -193,11 +193,15 @@ prometheusRule:
       thresholdPercent: 90
     apiServerLatencyHigh:
       for: 10m
-    # IPv6 misconfiguration alert - fires on any active IPv6* node condition
-    # (sysctl, default route, link-local, global address, RA, firewall blackhole).
-    # Carries address_family=ipv6 so Alertmanager can route IPv6 issues separately.
+    # Consolidated IPv6 alert (fires on any condition_type=~"IPv6.*").
+    # Disabled by default: on mixed IPv4/dual-stack fleets the IPv6 monitors
+    # raise benign warnings on IPv4-only nodes, which would page here. Opt in
+    # (enabled: true) once IPv6 condition semantics are validated for your fleet.
+    # NOTE: this key MUST exist even when disabled — templates/prometheusrule.yaml
+    # references .ipv6Misconfigured.enabled/.for/.labels/.annotations, and a missing
+    # block makes `helm upgrade` nil-pointer whenever prometheusRule.enabled=true.
     ipv6Misconfigured:
-      enabled: true
+      enabled: false
       for: 10m
       labels: {}
       annotations: {}
@@ -211,13 +215,38 @@ prometheusRule:
     noMetrics:
       for: 10m
 
-# Health probe configuration
+# Cluster DNS via pod-network probe (task 242).
+# DISABLED by default. node-doctor runs hostNetwork and cannot resolve cluster DNS
+# ClusterIP records (Cilium host-netns->ClusterIP), so the in-agent cluster-DNS check
+# is off (dns-health clusterDomains: []). When enabled, this adds a monitor that queries
+# the overlay-test pods' /clusterdns endpoint (pod-network, which DOES resolve cluster
+# records) and drives ClusterDNSDown from that.
+# PREREQUISITE: the overlay-test image must serve /clusterdns (v1.8.3+). Enabling this
+# against an older overlay-test image makes every probe 404 -> false ClusterDNSDown.
+clusterDnsPodProbe:
+  enabled: false
+  interval: 30s
+  timeout: 5s
+  labelSelector: "app=node-doctor-overlay-test"
+  probePort: 8023
+  probePath: "/clusterdns"
+  # Number of overlay-test pods that must resolve cluster DNS for it to be healthy.
+  minSuccessPods: 1
+  # Consecutive failed cycles before ClusterDNSDown latches True.
+  failureCountThreshold: 3
+
+# Health probe configuration.
+# Probes default to `exec` running the binary's built-in health check, which talks
+# to a per-pod unix socket (/var/run/node-doctor/health.sock) instead of TCP :8080.
+# Because node-doctor runs with hostNetwork:true, a foreign host process (e.g. an
+# IP-float/VIP daemon on hostPort 8080) can answer an httpGet probe with a 404 and
+# crashloop the pod; the unix socket lives in the pod and cannot collide.
+# To revert to HTTP probes, replace the `exec:` block with `httpGet: {path, port}`.
 probes:
   liveness:
     enabled: true
-    httpGet:
-      path: /healthz
-      port: 8080
+    exec:
+      command: ["/usr/local/bin/node-doctor", "-healthcheck"]
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
@@ -225,9 +254,8 @@ probes:
     successThreshold: 1
   readiness:
     enabled: true
-    httpGet:
-      path: /ready
-      port: 8080
+    exec:
+      command: ["/usr/local/bin/node-doctor", "-healthcheck-ready"]
     initialDelaySeconds: 10
     periodSeconds: 5
     timeoutSeconds: 3
@@ -235,9 +263,8 @@ probes:
     successThreshold: 1
   startup:
     enabled: true
-    httpGet:
-      path: /healthz
-      port: 8080
+    exec:
+      command: ["/usr/local/bin/node-doctor", "-healthcheck"]
     initialDelaySeconds: 10
     periodSeconds: 5
     timeoutSeconds: 3
@@ -445,9 +472,8 @@ features:
   enableProfiling: false
   enableTracing: false
 
-# Overlay Test Configuration
-# Deploys lightweight Go HTTP health server pods WITHOUT hostNetwork
-# for accurate CNI/overlay testing via HTTP probes (fixes Cilium ICMP issue)
+# Overlay test configuration for CNI connectivity testing
+# Uses Go HTTP health server for accurate probing (fixes Cilium ICMP issue)
 overlayTest:
   # Enable overlay test pods - required for accurate CNI connectivity testing
   enabled: true
@@ -455,13 +481,17 @@ overlayTest:
   # Image for overlay test pods (Go HTTP health server, scratch-based ~6MB)
   image:
     repository: supporttools/node-doctor-overlay-test
-    tag: ""  # defaults to Chart appVersion
+    tag: "v1.0.0"
     pullPolicy: IfNotPresent
 
   # HTTP health probe port
   port: 8023
 
-  # Resource limits for overlay test pods
+  # Resource limits for overlay test pods.
+  # Do NOT lower the CPU limit back toward 10m. At 10m the pod sat 88-93% CFS-throttled
+  # and inflated its own HTTP probe latency from ~3ms to 300-500ms, which node-doctor
+  # then reported as peer/CNI latency and turned into false NetworkDegraded and
+  # HighPeerLatency alerts. 100m leaves enough headroom that throttling stops.
   resources:
     requests:
       cpu: 5m
@@ -477,7 +507,6 @@ overlayTest:
   # Priority class (empty = no priority class)
   priorityClassName: ""
 
-# Controller configuration - optional central aggregation component
 controller:
   # Enable the node-doctor controller (requires persistent storage)
   enabled: false

--- a/helm/node-doctor/values.yaml.template
+++ b/helm/node-doctor/values.yaml.template
@@ -487,13 +487,17 @@ overlayTest:
   # HTTP health probe port
   port: 8023
 
-  # Resource limits for overlay test pods
+  # Resource limits for overlay test pods.
+  # Do NOT lower the CPU limit back toward 10m. At 10m the pod sat 88-93% CFS-throttled
+  # and inflated its own HTTP probe latency from ~3ms to 300-500ms, which node-doctor
+  # then reported as peer/CNI latency and turned into false NetworkDegraded and
+  # HighPeerLatency alerts. 100m leaves enough headroom that throttling stops.
   resources:
     requests:
-      cpu: 1m
+      cpu: 5m
       memory: 8Mi
     limits:
-      cpu: 10m
+      cpu: 100m
       memory: 16Mi
 
   # Update strategy


### PR DESCRIPTION
## Why

The overlay-test pod has run with a **10m CPU limit in production for six months** despite `8d555e8` (2026-02-11) raising it to 100m. At 10m it sits **88-93% CFS-throttled**, which inflates its own HTTP probe latency from ~3ms to 300-500ms. node-doctor reports that as peer/CNI latency, producing false `NetworkDegraded` and `HighPeerLatency` alerts. Measured on a1-ops-prd 2026-08-12: ipv4 peer latency 300-600ms across 12 of 13 colo-local nodes where real RTT is sub-millisecond.

## Root cause — not what the ticket assumed

`8d555e8` was **not** stranded on an unmerged branch. It shipped in `v1.7.1` through `v1.8.6`. Only half of it took effect:

| Part of `8d555e8` | File | Live? |
|---|---|---|
| latency 200ms / 500ms | `templates/configmap.yaml` | ✅ yes |
| CNI Go defaults | `pkg/monitors/network/cni.go` | ✅ yes |
| overlay-test CPU 5m/100m | `helm/node-doctor/values.yaml` | ❌ **never shipped** |

`release.yml:242-247` deletes `helm/node-doctor/{Chart,values}.yaml` and re-renders them from the `*.template` files before packaging:

```
rm -f helm/node-doctor/Chart.yaml helm/node-doctor/values.yaml
envsubst < helm/node-doctor/values.yaml.template > helm/node-doctor/values.yaml
```

So the published chart's values come from `values.yaml.template`, which still read `cpu: 1m` / `cpu: 10m`. Edits to the committed `values.yaml` are silently discarded at package time — no error, no warning, and `.helmignore` excludes the templates so the tarball looks normal. Everything under `templates/` is packaged verbatim, which is why the configmap half of the same commit went live.

Confirmed from the live release: `helm get manifest` renders `cpu: 10m` while git tag `v1.8.6` has `cpu: 100m`.

## Changes

- **`values.yaml.template`** — overlay-test CPU to 5m/100m. This is the actual fix.
- **`templates/overlay-test-daemonset.yaml`** — the `| default "1m"` / `| default "10m"` fallbacks re-armed the old values whenever the key was absent; aligned to 5m/100m.
- **`values.yaml`** — regenerated from the template. It had drifted 68 lines behind on `clusterDnsPodProbe`, `ipv6Misconfigured` and the `exec:` health probes. **Zero production impact** — this file never reaches the published chart.
- **`prometheusrule.yaml` (both copies)** — bundles node-doctor-250. `changes(node_doctor_monitor_uptime_seconds[5m]) > 0` counts scrapes, not restarts, so the alert was permanently true on all 13 nodes and never once signalled a real restart. Replaced with `node_doctor_monitor_uptime_seconds < 600`. Bundled deliberately: without it this upgrade reverts the live hand-patched rule and restores 13 permanent alerts.
- **`Makefile`** — `make helm-generate` renders both chart files; `make helm-verify-generated` diffs and fails on drift; `helm-lint` depends on it.
- **`ci.yml`** — new `Helm Chart` job runs the guard plus `helm lint`. Wired into `ci-success` so no branch-protection check rename is needed.
- **`docs/release-process.md`** — documents which chart files actually ship.

## Verification

- `make build`, `make test` pass.
- `make helm-lint` passes; guard negative-tested (edited `values.yaml` → exit 2 with the drift error).
- `helm template` renders overlay-test at `requests.cpu 5m` / `limits.cpu 100m`, and the alert as `node_doctor_monitor_uptime_seconds < 600` with `for: 0m`.

Post-release verification on a1-ops-prd is tracked in the task: `helm get manifest` must show 100m (not just the live DaemonSet), CFS throttle ratio well under 40%, ipv4 peer latency in single-digit ms. Note `NodeDoctorAgentRestarted` fires legitimately for ~10 min after the rollout as agents cross 600s uptime.

Task: #node-doctor-252
Task: #node-doctor-250

https://claude.ai/code/session_01Av4whriQf6KqJgRxGKQP7N