### PR TITLE
fix(helm): raise agent CPU limit to 500m and un-wedge DaemonSet rollouts (234, 244)

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -283,7 +283,7 @@ kubectl get events -n kube-system --field-selector involvedObject.name=node-doct
 1. **Resource Monitoring**: Monitor CPU/memory usage across nodes
 2. **Log Rotation**: Ensure log rotation is configured for container logs
 3. **Alerting**: Set up alerts for Node Doctor health and node conditions
-4. **Updates**: Use rolling updates with `maxUnavailable: 1`
+4. **Updates**: Use rolling updates with `maxUnavailable: 25%` - a percentage, not `1`, so a single crashlooping pod cannot consume the whole budget and stall the rollout at 0/N
 5. **Backup**: Include ConfigMap in cluster backup procedures
 
 ## Security Best Practices

--- a/deployment/daemonset.yaml
+++ b/deployment/daemonset.yaml
@@ -13,11 +13,17 @@ metadata:
     description: "Node Doctor - Kubernetes node monitoring and auto-remediation DaemonSet"
     docs: "https://github.com/supporttools/node-doctor"
 spec:
-  # Rolling update strategy - update one node at a time for safety
+  # Rolling update strategy.
+  # maxUnavailable is a PERCENTAGE, not 1, on purpose. With maxUnavailable: 1 a single
+  # already-crashlooping pod consumes the entire unavailable budget and no other pod can
+  # be rolled - `kubectl rollout restart` then stalls at 0/N forever and the only recovery
+  # is manually deleting healthy pods. 25% leaves room to roll past a stuck node.
+  # Do NOT add maxSurge: this DaemonSet is hostNetwork with a hostPort, so a surge pod
+  # would collide with the pod it replaces on the same node and never become ready.
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 1  # Only update one pod at a time to maintain cluster stability
+      maxUnavailable: "25%"
 
   selector:
     matchLabels:
@@ -191,8 +197,12 @@ spec:
             # Memory: 128Mi - sufficient for monitoring data structures
             memory: 128Mi
           limits:
-            # CPU: 200m (0.2 cores) - prevent runaway CPU usage
-            cpu: 200m
+            # CPU: 500m (0.5 cores) - burst headroom for probe cycles.
+            # Do NOT lower back toward 200m. At 200m the agent sat 30-71% CFS-throttled
+            # across a 13-node fleet (median 44.2%). The agent is the process that
+            # performs the probing, so its own scheduling delay is added to every RTT it
+            # measures and reports as network latency.
+            cpu: 500m
             # Memory: 256Mi - prevent memory leaks from affecting node
             memory: 256Mi
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -392,7 +392,7 @@ spec:
             cpu: 50m
             memory: 128Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 256Mi
 
         volumeMounts:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -55,7 +55,7 @@ resources:
     cpu: 50m
     memory: 128Mi
   limits:
-    cpu: 200m
+    cpu: 500m
     memory: 256Mi
 
 serviceMonitor:
@@ -399,7 +399,7 @@ kubectl get all -n kube-system -l app=node-doctor
 4. **Monitoring Integration**: Configure Prometheus ServiceMonitor or PodMonitor
 5. **Alerting**: Set up alerts for NodeDoctorHealthy condition changes
 6. **Backup**: Include ConfigMap in cluster backup procedures
-7. **Updates**: Use rolling updates with maxUnavailable: 1 for safety
+7. **Updates**: Use rolling updates with maxUnavailable: 25% - a percentage, not 1, so a single crashlooping pod cannot consume the whole budget and stall the rollout at 0/N
 
 ## Support
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -241,7 +241,7 @@ resources:
     cpu: 50m
     memory: 128Mi
   limits:
-    cpu: 200m
+    cpu: 500m
     memory: 256Mi
 ```
 

--- a/helm/node-doctor/README.md
+++ b/helm/node-doctor/README.md
@@ -64,8 +64,31 @@ The following table lists the configurable parameters of the Node Doctor chart a
 |-----------|-------------|---------|
 | `resources.requests.cpu` | CPU request | `50m` |
 | `resources.requests.memory` | Memory request | `128Mi` |
-| `resources.limits.cpu` | CPU limit | `200m` |
+| `resources.limits.cpu` | CPU limit | `500m` |
 | `resources.limits.memory` | Memory limit | `256Mi` |
+
+> **Do not lower `resources.limits.cpu` back toward `200m`.** At a 200m limit the agent
+> ran 30-71% CFS-throttled across a 13-node fleet (median 44.2%). The agent is the
+> process that performs the network/DNS probing, so its own scheduling delay is added to
+> every RTT it measures, which inflates reported latency and can produce false
+> `NetworkDegraded` / `HighPeerLatency` findings. Requests stay low (`50m`) because
+> sustained usage is well under the limit - what the agent needs is burst headroom, not
+> reserved capacity on every node.
+
+### Update Strategy
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `updateStrategy.type` | DaemonSet update strategy | `RollingUpdate` |
+| `updateStrategy.rollingUpdate.maxUnavailable` | Pods that may be unavailable during a roll | `25%` |
+
+`maxUnavailable` is deliberately a percentage rather than `1`. With `maxUnavailable: 1`
+a single already-crashlooping pod consumes the whole unavailable budget and the rollout
+never progresses (see [DaemonSet rollout is stuck](#daemonset-rollout-is-stuck-at-0n)).
+
+Do **not** set `maxSurge`. The agent runs with `hostNetwork: true` and a hostPort, so a
+surge pod would conflict with the pod it is replacing on the same node and never become
+ready.
 
 ### Monitor Configuration
 
@@ -171,6 +194,58 @@ kubectl logs -n node-doctor -l app.kubernetes.io/name=node-doctor --tail=100
 ```bash
 kubectl get nodes -o custom-columns='NAME:.metadata.name,HEALTHY:.status.conditions[?(@.type=="NodeDoctorHealthy")].status'
 ```
+
+### DaemonSet rollout is stuck at 0/N
+
+A DaemonSet rollout only replaces pods while fewer than
+`updateStrategy.rollingUpdate.maxUnavailable` pods are unavailable. Pods that were
+**already** unhealthy before the roll started (CrashLoopBackOff, ImagePullBackOff,
+Pending on a cordoned/full node) count against that budget. If enough of them are stuck,
+the controller has no budget left and `kubectl rollout restart` sits at `0/N updated`
+indefinitely - nothing is wrong with the new revision, the roll simply never starts.
+
+The chart ships `maxUnavailable: 25%` so a single stuck pod can no longer wedge the
+whole roll, but a large enough group of unhealthy pods can still exhaust the budget.
+
+Confirm that is what is happening:
+
+```bash
+# Rollout makes no progress
+kubectl rollout status daemonset/node-doctor -n node-doctor --timeout=60s
+
+# Budget in effect and how many pods are actually unavailable
+kubectl get daemonset node-doctor -n node-doctor \
+  -o jsonpath='{.spec.updateStrategy.rollingUpdate.maxUnavailable}{"\n"}'
+kubectl get daemonset node-doctor -n node-doctor \
+  -o custom-columns='DESIRED:.status.desiredNumberScheduled,READY:.status.numberReady,UPDATED:.status.updatedNumberScheduled,UNAVAILABLE:.status.numberUnavailable'
+
+# Which pods are holding the budget
+kubectl get pods -n node-doctor -l app.kubernetes.io/name=node-doctor \
+  --field-selector=status.phase!=Running -o wide
+kubectl get pods -n node-doctor -l app.kubernetes.io/name=node-doctor \
+  -o wide | grep -v ' Running '
+```
+
+**Recovery.** Fix or remove the blocking pods so the budget frees up. The stuck pod is
+the one to delete first - deleting it lets the DaemonSet recreate it at the new revision:
+
+```bash
+# 1. Delete the pods that are already unhealthy (they are recreated at the new revision)
+kubectl delete pod -n node-doctor <stuck-pod-name>
+
+# 2. If the roll still does not move, delete healthy pods a few at a time to force
+#    replacement. Verify each batch comes back Ready before deleting the next.
+kubectl delete pod -n node-doctor <healthy-pod-name>
+kubectl rollout status daemonset/node-doctor -n node-doctor --timeout=120s
+```
+
+Deleting node-doctor pods is safe: it is a stateless per-node agent, and while a pod is
+gone that node simply reports no fresh findings. Do not delete every pod at once -
+staggering keeps node condition reporting continuous across the cluster.
+
+If the blocking pod is stuck because its node is unreachable or NotReady, drain or
+delete the node object instead; the pod will not terminate on its own while the kubelet
+is unreachable.
 
 ### View Prometheus Metrics
 

--- a/helm/node-doctor/values.yaml
+++ b/helm/node-doctor/values.yaml
@@ -271,13 +271,21 @@ probes:
     failureThreshold: 20
     successThreshold: 1
 
-# Resource limits and requests
+# Resource limits and requests for the node-doctor agent.
+# Do NOT lower the CPU limit back toward 200m. At 200m the agent sat 30-71% CFS-throttled
+# across a 13-node fleet (10m rate, measured 2026-08-12: median 44.2%, max 71.3% on
+# a1pinode02). The agent is the process that PERFORMS the probing, so its own scheduling
+# delay is added to every RTT it measures and reports - the same failure mode that made
+# the overlay-test pod invent peer/CNI latency at a 10m limit (see overlayTest.resources
+# below). Sustained usage is far below the limit; the problem is burst headroom during
+# probe cycles, so 500m is the limit and requests stay low (50m) to avoid reserving
+# capacity on every node in the cluster for a burst that is idle most of the time.
 resources:
   requests:
     cpu: 50m
     memory: 128Mi
   limits:
-    cpu: 200m
+    cpu: 500m
     memory: 256Mi
 
 # Node selector - run on all Linux nodes
@@ -321,11 +329,19 @@ tolerations:
 # Affinity rules
 affinity: {}
 
-# Update strategy for the DaemonSet
+# Update strategy for the DaemonSet.
+# maxUnavailable is a PERCENTAGE, not 1, on purpose. With maxUnavailable: 1 a single
+# already-crashlooping pod consumes the entire unavailable budget and no other pod can
+# ever be rolled - `kubectl rollout restart` then stalls at 0/N forever and the only
+# recovery is manually deleting healthy pods (see "DaemonSet rollout is stuck" in
+# README.md). 25% matches overlayTest.updateStrategy below and leaves room for the roll
+# to make progress past a stuck node.
+# Do NOT add maxSurge here: the agent runs hostNetwork with a hostPort, so a surge pod
+# would collide with the pod it is replacing on the same node and never become ready.
 updateStrategy:
   type: RollingUpdate
   rollingUpdate:
-    maxUnavailable: 1
+    maxUnavailable: "25%"
 
 # Termination grace period
 terminationGracePeriodSeconds: 30

--- a/helm/node-doctor/values.yaml.template
+++ b/helm/node-doctor/values.yaml.template
@@ -271,13 +271,21 @@ probes:
     failureThreshold: 20
     successThreshold: 1
 
-# Resource limits and requests
+# Resource limits and requests for the node-doctor agent.
+# Do NOT lower the CPU limit back toward 200m. At 200m the agent sat 30-71% CFS-throttled
+# across a 13-node fleet (10m rate, measured 2026-08-12: median 44.2%, max 71.3% on
+# a1pinode02). The agent is the process that PERFORMS the probing, so its own scheduling
+# delay is added to every RTT it measures and reports - the same failure mode that made
+# the overlay-test pod invent peer/CNI latency at a 10m limit (see overlayTest.resources
+# below). Sustained usage is far below the limit; the problem is burst headroom during
+# probe cycles, so 500m is the limit and requests stay low (50m) to avoid reserving
+# capacity on every node in the cluster for a burst that is idle most of the time.
 resources:
   requests:
     cpu: 50m
     memory: 128Mi
   limits:
-    cpu: 200m
+    cpu: 500m
     memory: 256Mi
 
 # Node selector - run on all Linux nodes
@@ -321,11 +329,19 @@ tolerations:
 # Affinity rules
 affinity: {}
 
-# Update strategy for the DaemonSet
+# Update strategy for the DaemonSet.
+# maxUnavailable is a PERCENTAGE, not 1, on purpose. With maxUnavailable: 1 a single
+# already-crashlooping pod consumes the entire unavailable budget and no other pod can
+# ever be rolled - `kubectl rollout restart` then stalls at 0/N forever and the only
+# recovery is manually deleting healthy pods (see "DaemonSet rollout is stuck" in
+# README.md). 25% matches overlayTest.updateStrategy below and leaves room for the roll
+# to make progress past a stuck node.
+# Do NOT add maxSurge here: the agent runs hostNetwork with a hostPort, so a surge pod
+# would collide with the pod it is replacing on the same node and never become ready.
 updateStrategy:
   type: RollingUpdate
   rollingUpdate:
-    maxUnavailable: 1
+    maxUnavailable: "25%"
 
 # Termination grace period
 terminationGracePeriodSeconds: 30


### PR DESCRIPTION
Fixes two defects on the node-doctor **agent** container. Both live in `helm/node-doctor/values.yaml.template` (regenerated into `values.yaml` via `make helm-generate`) and are mirrored into the raw `deployment/daemonset.yaml`.

## 234 — agent CPU limit causes 30-71% CFS throttling

The agent ran at `limits.cpu=200m`. Measured on the 13-node cluster 2026-08-12 (10m rate):

| node | throttle % | | node | throttle % |
|---|---|---|---|---|
| a1pinode02 | 71.3 | | a1ubopsp06 | 47.4 |
| a1ubr720p05 | 69.1 | | a1ubmgmtp02 | 44.5 |
| a1ubaip01 | 58.5 | | a0ublokip01 | 41.0 |
| a1ubr720p02 | 57.0 | | a1ubr720p04 | 41.0 |
| a1pinode01 | 55.8 | | a1ubmgmtp03 | 39.1 |
| a1ubr720p03 | 49.8 | | a1ubmgmtp01 | 38.9 |
| | | | a1ubofficep01 | 36.6 |

min 30.7%, median 44.2%, max 71.3% — **every node in the fleet was throttled.**

This is worse than resource hygiene. It is the **same failure mode fixed in task 252, one container over.** There, the overlay-test pod's 10m limit caused ~90% throttling that inflated its *own* HTTP probe latency from ~3ms to 300-500ms, which node-doctor then reported as network latency and turned into false `NetworkDegraded` / `HighPeerLatency` alerts. The agent is the container that **performs** the probing, so its scheduling delay is added directly to every RTT it measures and reports. At a median 44% throttle, some fraction of the latency this fleet's node-doctor reports is plausibly the agent waiting for CPU rather than anything on the wire.

**`limits.cpu`: `200m` → `500m`.** Requests stay at `50m` — sustained usage is far below the limit, the problem is burst headroom during probe cycles, and this is a DaemonSet, so bumping requests reserves capacity on *every* node for a burst that is idle most of the time. Memory unchanged. A comment at the site explains why it must not be lowered back, mirroring the existing `overlayTest.resources` comment.

## 244 — DaemonSet rollout stalls when a crashlooping pod consumes maxUnavailable:1

`kubectl rollout restart` of the node-doctor DaemonSet stalled at **0/12** because one *already*-crashlooping pod counted against `maxUnavailable: 1`. With the entire unavailable budget consumed, no other pod could ever be rolled — nothing was wrong with the new revision, the roll simply never started. The live workaround was manually deleting healthy pods.

**`updateStrategy.rollingUpdate.maxUnavailable`: `1` → `"25%"`**, matching the in-repo precedent already used by `overlayTest.updateStrategy`. DaemonSet scales percentages up, so a 12-node roll gets a budget of 3 and a single stuck pod can no longer wedge it.

**No `maxSurge`** — as specified, the agent runs `hostNetwork` with a hostPort, so a surge pod would collide with the pod it replaces on the same node and never become ready.

The manual-delete recovery procedure is documented in a new **"DaemonSet rollout is stuck at 0/N"** section in `helm/node-doctor/README.md`, with diagnosis commands (which pods hold the budget) and the staged-delete recovery, plus a note that 25% still is not immunity if a large enough group of pods is unhealthy.

## Outside the stated scope — worth a look

`deployment/daemonset.yaml` carried **both identical defects** (`cpu: 200m`, `maxUnavailable: 1`). This is not a docs sample: it is applied by `make deploy-prd`, applied by `.github/workflows/release.yml`, and shipped as a release asset. Fixing only the Helm chart would have left the fix undeployed on that path — the same shape of trap as task 252. Fixed there too.

Docs stating the old defaults (`docs/deployment.md`, `docs/quick-start.md`, `docs/architecture.md`) and the two "use rolling updates with `maxUnavailable: 1`" recommendations (`deployment/README.md`, `docs/deployment.md`) were updated so they stop teaching the value this PR is removing.

## Verification

- `make build` — pass
- `make test` — pass
- `make helm-lint` (includes `helm-verify-generated`) — pass, no template/generated drift
- `helm template node-doctor ./helm/node-doctor` — agent container renders `limits.cpu: 500m` / `requests.cpu: 50m`, DaemonSet renders `maxUnavailable: 25%`, no `maxSurge`
- `kubectl apply --dry-run=client -f deployment/daemonset.yaml` — parses clean

`values.yaml.template` was edited and `make helm-generate` run; both the template and the generated `values.yaml` are committed.

Task: #node-doctor-234
Task: #node-doctor-244

https://claude.ai/code/session_01Av4whriQf6KqJgRxGKQP7N
