### PR TITLE
fix(dns): stop pinning cluster.local in the auto-default DNS monitor config (task 241)

### DIFF
--- a/pkg/monitors/network/dns.go
+++ b/pkg/monitors/network/dns.go
@@ -590,7 +590,18 @@ func init() {
 			IntervalString: "30s",
 			TimeoutString:  "10s",
 			Config: map[string]interface{}{
-				"clusterDomains":         []interface{}{"kubernetes.default.svc.cluster.local"},
+				// NOTE: "clusterDomains" is deliberately ABSENT here, not set to
+				// "kubernetes.default.svc.cluster.local". This map is injected verbatim by
+				// ApplyDefaultMonitors when a config omits network-dns-check, and any value
+				// present here is an EXPLICIT setting that wins over derivation in
+				// applyDefaults (which only fills a nil ClusterDomains). Hardcoding
+				// cluster.local here therefore pins every auto-defaulted node to a name that
+				// is a guaranteed NXDOMAIN on clusters with a custom cluster-domain (RKE2
+				// `cluster-domain`), producing fleet-wide false ClusterDNSResolutionFailed.
+				// Leaving the key unset lets applyDefaults derive the real domain from the
+				// resolver search list (see defaultClusterDomains / pkg/clusterdns), while
+				// operators can still set clusterDomains explicitly — including [] to
+				// disable the cluster check entirely, as the Helm chart does.
 				"externalDomains":        []interface{}{"google.com", "cloudflare.com"},
 				"latencyThreshold":       "1s",
 				"checkNameservers":       true,

--- a/pkg/monitors/network/dns_clusterdomain_test.go
+++ b/pkg/monitors/network/dns_clusterdomain_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/supporttools/node-doctor/pkg/monitors"
 )
 
 func writeResolv(t *testing.T, content string) string {
@@ -54,5 +56,177 @@ func TestApplyDefaultsDerivesClusterDomain(t *testing.T) {
 	}
 	if len(disabled.ClusterDomains) != 0 {
 		t.Errorf("explicit empty ClusterDomains should stay empty, got %v", disabled.ClusterDomains)
+	}
+}
+
+// TestDeriveClusterDomainFromResolvConf is the table-driven contract for deriving the
+// cluster domain from an INJECTED resolv.conf path (never the real /etc/resolv.conf),
+// covering the standard domain, a custom cluster-domain, malformed/missing files, and an
+// empty search list. Cases that cannot be derived must fall back to cluster.local rather
+// than probing a bogus name.
+func TestDeriveClusterDomainFromResolvConf(t *testing.T) {
+	tests := []struct {
+		name string
+		// resolv is the resolv.conf content; when writeFile is false the path is left
+		// nonexistent to exercise the unreadable-file path.
+		resolv    string
+		writeFile bool
+		want      string
+	}{
+		{
+			name:      "standard cluster.local search list",
+			resolv:    "search default.svc.cluster.local svc.cluster.local cluster.local\nnameserver 10.43.0.10\noptions ndots:5\n",
+			writeFile: true,
+			want:      "kubernetes.default.svc.cluster.local",
+		},
+		{
+			name:      "custom cluster domain (RKE2 cluster-domain, the incident case)",
+			resolv:    "search default.svc.a1-ops-prd.local svc.a1-ops-prd.local a1-ops-prd.local\nnameserver 10.43.0.10\noptions ndots:5\n",
+			writeFile: true,
+			want:      "kubernetes.default.svc.a1-ops-prd.local",
+		},
+		{
+			name:      "missing resolv.conf falls back to cluster.local",
+			writeFile: false,
+			want:      "kubernetes.default.svc.cluster.local",
+		},
+		{
+			name:      "malformed resolv.conf falls back to cluster.local",
+			resolv:    "this is not a resolv.conf\n\x00\x01garbage!!\nsearchsomething\n",
+			writeFile: true,
+			want:      "kubernetes.default.svc.cluster.local",
+		},
+		{
+			name:      "empty search list falls back to cluster.local",
+			resolv:    "search\nnameserver 10.43.0.10\n",
+			writeFile: true,
+			want:      "kubernetes.default.svc.cluster.local",
+		},
+		{
+			name:      "no search line at all falls back to cluster.local",
+			resolv:    "nameserver 1.1.1.1\noptions ndots:5\n",
+			writeFile: true,
+			want:      "kubernetes.default.svc.cluster.local",
+		},
+		{
+			name:      "non-Kubernetes search list falls back to cluster.local",
+			resolv:    "search corp.example.com example.com\nnameserver 1.1.1.1\n",
+			writeFile: true,
+			want:      "kubernetes.default.svc.cluster.local",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "resolv.conf")
+			if tt.writeFile {
+				if err := os.WriteFile(path, []byte(tt.resolv), 0o644); err != nil {
+					t.Fatalf("write resolv.conf: %v", err)
+				}
+			}
+
+			// The path is injected, so this test never touches the host's real
+			// /etc/resolv.conf and is safe to run anywhere.
+			c := &DNSMonitorConfig{ResolverPath: path}
+			if err := c.applyDefaults(); err != nil {
+				t.Fatalf("applyDefaults: %v", err)
+			}
+
+			if len(c.ClusterDomains) != 1 || c.ClusterDomains[0] != tt.want {
+				t.Errorf("derived ClusterDomains = %v, want [%q]", c.ClusterDomains, tt.want)
+			}
+		})
+	}
+}
+
+// TestExplicitClusterDomainsBeatDerivation pins that operator-supplied config always wins
+// over runtime derivation, in both directions: an explicit non-empty list is used verbatim
+// even when the resolver would derive something else, and an explicit empty list keeps the
+// cluster-DNS check disabled.
+func TestExplicitClusterDomainsBeatDerivation(t *testing.T) {
+	// A resolver that WOULD derive kubernetes.default.svc.derived.zone.
+	resolv := writeResolv(t, "search default.svc.derived.zone svc.derived.zone derived.zone\nnameserver 10.96.0.10\n")
+
+	tests := []struct {
+		name       string
+		configured []string
+		want       []string
+	}{
+		{
+			name:       "explicit single domain wins over derivation",
+			configured: []string{"kubernetes.default.svc.operator.choice"},
+			want:       []string{"kubernetes.default.svc.operator.choice"},
+		},
+		{
+			name:       "explicit multiple domains win over derivation",
+			configured: []string{"kubernetes.default.svc.one.zone", "kube-dns.kube-system.svc.two.zone"},
+			want:       []string{"kubernetes.default.svc.one.zone", "kube-dns.kube-system.svc.two.zone"},
+		},
+		{
+			name:       "explicit empty list keeps the cluster check disabled",
+			configured: []string{},
+			want:       []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &DNSMonitorConfig{ResolverPath: resolv, ClusterDomains: tt.configured}
+			if err := c.applyDefaults(); err != nil {
+				t.Fatalf("applyDefaults: %v", err)
+			}
+
+			if len(c.ClusterDomains) != len(tt.want) {
+				t.Fatalf("ClusterDomains = %v, want %v", c.ClusterDomains, tt.want)
+			}
+			for i, want := range tt.want {
+				if c.ClusterDomains[i] != want {
+					t.Errorf("ClusterDomains[%d] = %q, want %q", i, c.ClusterDomains[i], want)
+				}
+			}
+		})
+	}
+}
+
+// TestRegistryDefaultConfigDoesNotPinClusterDomain guards the auto-default path. The
+// registry DefaultConfig map is injected verbatim by ApplyDefaultMonitors for any config
+// that omits network-dns-check, and anything set there counts as EXPLICIT config that
+// beats derivation. A hardcoded "kubernetes.default.svc.cluster.local" in that map is the
+// exact footgun that NXDOMAINs fleet-wide on a custom cluster-domain, so the key must stay
+// absent and let applyDefaults derive it.
+func TestRegistryDefaultConfigDoesNotPinClusterDomain(t *testing.T) {
+	info := monitors.GetMonitorInfo("network-dns-check")
+	if info == nil || info.DefaultConfig == nil {
+		t.Fatal("network-dns-check has no registered DefaultConfig")
+	}
+
+	if val, present := info.DefaultConfig.Config["clusterDomains"]; present {
+		t.Errorf("registry DefaultConfig pins clusterDomains=%v; it must be absent so the "+
+			"cluster domain is derived from the resolver search list at runtime", val)
+	}
+
+	// The auto-default must still be a valid config (validation requires at least one of
+	// clusterDomains/externalDomains/customQueries) — externalDomains carries it.
+	if err := ValidateDNSConfig(*info.DefaultConfig); err != nil {
+		t.Errorf("registry DefaultConfig fails validation: %v", err)
+	}
+
+	// End-to-end: parsing the registry default leaves ClusterDomains nil, so applyDefaults
+	// derives the real domain from the injected resolver rather than assuming cluster.local.
+	parsed, err := parseDNSConfig(info.DefaultConfig.Config)
+	if err != nil {
+		t.Fatalf("parseDNSConfig(DefaultConfig): %v", err)
+	}
+	if parsed.ClusterDomains != nil {
+		t.Fatalf("parsed ClusterDomains = %v, want nil so derivation applies", parsed.ClusterDomains)
+	}
+
+	parsed.ResolverPath = writeResolv(t, "search default.svc.a1-ops-prd.local svc.a1-ops-prd.local a1-ops-prd.local\nnameserver 10.43.0.10\n")
+	if err := parsed.applyDefaults(); err != nil {
+		t.Fatalf("applyDefaults: %v", err)
+	}
+	want := "kubernetes.default.svc.a1-ops-prd.local"
+	if len(parsed.ClusterDomains) != 1 || parsed.ClusterDomains[0] != want {
+		t.Errorf("auto-defaulted ClusterDomains = %v, want [%q]", parsed.ClusterDomains, want)
 	}
 }


### PR DESCRIPTION
## Problem

Runtime derivation of the cluster domain from `/etc/resolv.conf` already landed in d14472d (`pkg/clusterdns` + `defaultClusterDomains`). But the **registry `DefaultConfig`** for `network-dns-check` still hardcoded:

```go
"clusterDomains": []interface{}{"kubernetes.default.svc.cluster.local"},
```

`ApplyDefaultMonitors` injects that map **verbatim** into any configuration that omits `network-dns-check`, and `applyDefaults` only derives when `ClusterDomains` is `nil`. So a value present in that map counts as *explicit operator config* and **beats derivation**.

Net effect: every auto-defaulted node was still pinned to `kubernetes.default.svc.cluster.local` — a guaranteed NXDOMAIN on clusters provisioned with a custom RKE2 `cluster-domain` (e.g. `a1-ops-prd.local`). That is the fleet-wide false `ClusterDNSResolutionFailed` that triggered the 1.8.0 rollback.

The Helm chart's own comment already named this as the reason it must ship an explicit `dns-health` entry:

> Without this explicit entry, ApplyDefaultMonitors adds a dns-health with the cluster.local default and the false positives return.

## Fix

Remove the key from the registry `DefaultConfig`. `ClusterDomains` stays `nil`, so `applyDefaults` derives `kubernetes.default.svc.<real domain>` from the injected `ResolverPath`, falling back to `cluster.local` only when derivation is not possible.

- Explicit config still wins in both directions, including `clusterDomains: []` to disable the cluster check entirely.
- The default still validates — `externalDomains` satisfies the "at least one check configured" requirement.

## Production impact: none

The deployed chart config sets `dns-health` with `clusterDomains: []` explicitly. Explicit config beats derivation, so that path is byte-for-byte unaffected and the `cluster-dns-pod` overlay-test probe remains the source of cluster-DNS truth. This change only affects configurations that **omit** `network-dns-check` and fall through to the registry default — which previously got the broken hardcoded name. No chart changes, so no `values.yaml` regeneration needed.

## Scope

Per the task, this does **not** attempt to fix hostNetwork cluster-DNS resolution (kube-dns ClusterIP is unreachable from host netns under Cilium) — that is node-doctor-242 / the `cluster-dns-pod` probe, already shipped.

## Tests

Table-driven, always against an **injected** resolv.conf path (never the host's `/etc/resolv.conf`):

- standard `cluster.local` search list
- custom cluster-domain (`a1-ops-prd.local`, the incident case)
- missing / malformed / empty-`search` / non-Kubernetes resolv.conf → fall back to `cluster.local`
- explicit `clusterDomains` (single, multiple, and `[]`) beat derivation
- guard test pinning that the registry `DefaultConfig` carries no `clusterDomains` key, plus end-to-end `parseDNSConfig` → `applyDefaults` derivation

The guard test was verified to **fail** against the pre-fix `DefaultConfig`, then pass after.

`make build` and `make test` both pass.

Task: #node-doctor-241

https://claude.ai/code/session_01Av4whriQf6KqJgRxGKQP7N