### PR TITLE
chore(security): triage gosec alerts introduced in v1.8.0 (task 237)

### DIFF
--- a/pkg/monitors/kubernetes/kubelet.go
+++ b/pkg/monitors/kubernetes/kubelet.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/supporttools/node-doctor/pkg/monitors"
@@ -421,6 +422,19 @@ func isConnectionLevelError(err error) bool {
 	return false
 }
 
+// sanitizeLogValue strips control characters (including CR and LF) from s so
+// that a config-supplied value — a kubelet URL host, or an error string that
+// embeds one — cannot forge additional log lines when interpolated into a log
+// message. Printable content is left untouched.
+func sanitizeLogValue(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
+}
+
 // doRequestWithLoopbackFallback executes req against c.client. If the request
 // fails with a connection-level error (see isConnectionLevelError) and the
 // request targets a recognized loopback host, it rebuilds the request against
@@ -432,6 +446,11 @@ func isConnectionLevelError(err error) bool {
 // is false. The label argument ("healthz" or "metrics") is used only for
 // logging.
 func (c *defaultKubeletClient) doRequestWithLoopbackFallback(req *http.Request, label string) (resp *http.Response, usedFallback bool, err error) {
+	// #nosec G704 -- the request URL is the operator-configured healthz/metrics
+	// endpoint, validated at config load by validateKubeletURL (http/https only,
+	// host required) and defaulting to the local kubelet. Probing an
+	// operator-specified kubelet endpoint is this monitor's entire purpose; no
+	// request-time or otherwise untrusted input reaches this URL.
 	resp, err = c.client.Do(req)
 	if err == nil {
 		return resp, false, nil
@@ -452,6 +471,11 @@ func (c *defaultKubeletClient) doRequestWithLoopbackFallback(req *http.Request, 
 
 	// Rebuild the request against the alternate loopback, preserving method,
 	// context, and headers (including any auth header already applied).
+	// #nosec G704 -- fallbackURL is produced by loopbackFallbackURL, which only
+	// returns ok when the original host is a recognized loopback and rewrites
+	// the host to the opposite-family loopback ("::1" or "127.0.0.1"). Scheme,
+	// port, and path are carried over from the already-validated request URL,
+	// so the fallback can never target a non-loopback host.
 	fbReq, buildErr := http.NewRequestWithContext(req.Context(), req.Method, fallbackURL, nil)
 	if buildErr != nil {
 		// Could not build the fallback request; surface the original error.
@@ -459,9 +483,17 @@ func (c *defaultKubeletClient) doRequestWithLoopbackFallback(req *http.Request, 
 	}
 	fbReq.Header = req.Header.Clone()
 
+	// #nosec G706 -- every interpolated value is passed through
+	// sanitizeLogValue, which strips control characters (CR/LF included) so no
+	// value can forge a log line; label is a package-internal literal. The taint
+	// analyzer does not recognize the sanitizer.
 	log.Printf("[INFO] kubelet %s: loopback probe to %s failed (%v), retrying %s",
-		label, req.URL.Host, primaryErr, fbReq.URL.Host)
+		label, sanitizeLogValue(req.URL.Host), sanitizeLogValue(primaryErr.Error()),
+		sanitizeLogValue(fbReq.URL.Host))
 
+	// #nosec G704 -- fbReq targets the opposite-family loopback derived from the
+	// already-validated request URL by loopbackFallbackURL; see the annotation
+	// on its construction above.
 	resp, err = c.client.Do(fbReq)
 	if err != nil {
 		// Both families failed. Return the fallback error so the message

--- a/pkg/monitors/kubernetes/kubelet_loopback_test.go
+++ b/pkg/monitors/kubernetes/kubelet_loopback_test.go
@@ -11,6 +11,32 @@ import (
 	"time"
 )
 
+// TestSanitizeLogValue verifies that control characters (which could otherwise
+// be used to forge additional log lines) are stripped while printable content
+// is preserved verbatim.
+func TestSanitizeLogValue(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain host untouched", "127.0.0.1:10248", "127.0.0.1:10248"},
+		{"ipv6 host untouched", "[::1]:10248", "[::1]:10248"},
+		{"newline stripped", "host\ninjected", "hostinjected"},
+		{"crlf stripped", "host\r\n[ERROR] fake", "host[ERROR] fake"},
+		{"tab and escape stripped", "a\tb\x1bc", "abc"},
+		{"empty stays empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeLogValue(tt.in); got != tt.want {
+				t.Fatalf("sanitizeLogValue(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 // newLoopbackTestClient builds a defaultKubeletClient whose healthz/metrics
 // URLs point at the supplied addresses, with a short timeout and no auth.
 func newLoopbackTestClient(healthzURL, metricsURL string) *defaultKubeletClient {

--- a/pkg/monitors/network/ipv6_firewall.go
+++ b/pkg/monitors/network/ipv6_firewall.go
@@ -56,6 +56,15 @@ type CommandExecutor interface {
 	Run(ctx context.Context, name string, args ...string) ([]byte, error)
 }
 
+// ipv6FirewallAllowedBinaries is the exhaustive allow-list of binaries
+// defaultCommandExecutor may execute. The monitor's Backend config value only
+// ever selects between these two constants; it is never used as a command name
+// itself, and no operator-supplied string reaches exec.
+var ipv6FirewallAllowedBinaries = map[string]struct{}{
+	ip6tablesBinary: {},
+	nftBinary:       {},
+}
+
 // defaultCommandExecutor implements CommandExecutor using os/exec.
 type defaultCommandExecutor struct{}
 
@@ -64,6 +73,12 @@ func (e *defaultCommandExecutor) LookPath(name string) (string, error) {
 }
 
 func (e *defaultCommandExecutor) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	if _, ok := ipv6FirewallAllowedBinaries[name]; !ok {
+		return nil, fmt.Errorf("refusing to execute disallowed binary %q", name)
+	}
+	// #nosec G204 -- name is checked against the ipv6FirewallAllowedBinaries
+	// allow-list immediately above, so it can only ever be "ip6tables" or
+	// "nft"; args are fixed read-only listing verbs supplied by this package.
 	cmd := exec.CommandContext(ctx, name, args...)
 	return cmd.CombinedOutput()
 }

--- a/pkg/monitors/network/ipv6_neighbor.go
+++ b/pkg/monitors/network/ipv6_neighbor.go
@@ -573,6 +573,10 @@ func (m *IPv6NeighborMonitor) severity() types.EventSeverity {
 // Scope 0x20 = link-local, 0x00 = global. Parse errors on individual lines are
 // skipped; a read/open failure is returned to the caller.
 func parseIfInet6File(path string) ([]ipv6Address, error) {
+	// #nosec G304 -- path is always filepath.Join(config.ProcPath, "net/if_inet6")
+	// with a fixed relative suffix. Reading the operator-configured procfs root
+	// (default /proc, overridden only in tests) is this monitor's entire purpose;
+	// the path is not attacker-controlled.
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open %s: %w", path, err)
@@ -625,6 +629,10 @@ func parseHexScope(s string) (uint64, error) {
 // readSysctlInt reads a sysctl-style file and returns its integer value (after
 // trimming whitespace). Used for accept_ra / autoconf, which take values 0/1/2.
 func readSysctlInt(path string) (int, error) {
+	// #nosec G304 -- path comes from a filepath.Glob over the operator-configured
+	// procfs root (default /proc), or from filepath.Join against such a match.
+	// Reading these sysctl files is this monitor's entire purpose; the path is
+	// not attacker-controlled.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return 0, fmt.Errorf("failed to read %s: %w", path, err)

--- a/pkg/monitors/network/ipv6_sysctl.go
+++ b/pkg/monitors/network/ipv6_sysctl.go
@@ -341,6 +341,10 @@ func (m *IPv6SysctlMonitor) checkPerInterfaceDisableIPv6(status *types.Status) [
 // (trimmed of whitespace) is "1". Any other value is treated as false. Errors
 // are propagated.
 func readSysctlBool(path string) (bool, error) {
+	// #nosec G304 -- path is built from the operator-configured procfs root
+	// (default /proc) joined with fixed sysctl names, or from a filepath.Glob
+	// over that root. Reading these sysctl files is this monitor's entire
+	// purpose; the path is not attacker-controlled.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return false, fmt.Errorf("failed to read %s: %w", path, err)

--- a/pkg/monitors/network/pinger.go
+++ b/pkg/monitors/network/pinger.go
@@ -45,10 +45,15 @@ var pingerInstanceCounter uint32
 // the value is deterministic and unique per instance (no randomness required).
 func nextPingerID() uint16 {
 	n := atomic.AddUint32(&pingerInstanceCounter, 1)
-	id := uint16(os.Getpid()) + uint16(n)
+	// Mask both inputs to 16 bits before converting so the narrowing is
+	// provably in range rather than an implicit truncation. ICMP echo IDs are
+	// 16 bits wide, so discarding the high bits is the intended behavior.
+	pid := uint16(os.Getpid() & 0xFFFF)
+	seq := uint16(n & 0xFFFF)
+	id := pid + seq
 	if id == 0 {
 		// Avoid an all-zero ID, which is a poor discriminator on the wire.
-		id = uint16(n) | 0x8000
+		id = seq | 0x8000
 	}
 	return id
 }


### PR DESCRIPTION
## Summary

PR #22 introduced 11 gosec code-scanning alerts (10 error, 1 warning). They are advisory today (CI runs gosec with `-no-fail`, no branch protection) and all are expected-class for a privileged node agent — but an untriaged alert is indistinguishable from a real finding, so each is now either genuinely fixed or annotated with a justification.

No runtime behavior changes beyond the sanitization/typing fixes below.

## Per-alert disposition

| Alert | Location | Action | Justification |
|---|---|---|---|
| G115 x3 | `pkg/monitors/network/pinger.go:48,51` | **fix** | Mask `os.Getpid()` and the instance counter to 16 bits before converting, so the narrowing is provably in range. Behavior identical — Go narrowing already discarded the same high bits. |
| G204 | `pkg/monitors/network/ipv6_firewall.go:67` | **fix + annotate** | `defaultCommandExecutor.Run` now checks the binary name against an explicit `ipv6FirewallAllowedBinaries` allow-list adjacent to the exec call and refuses anything else. Both call sites already passed the `ip6tablesBinary`/`nftBinary` constants, so nothing reachable changes. |
| G706 (log injection) | `pkg/monitors/kubernetes/kubelet.go:462` | **fix + annotate** | Every interpolated value now goes through a new `sanitizeLogValue` helper that strips control characters (CR/LF included), so a config-supplied URL host — or an error embedding one — cannot forge a log line. Annotated additionally because gosec's taint analyzer does not recognize the sanitizer. |
| G704 (SSRF) x3 | `pkg/monitors/kubernetes/kubelet.go:435,455,465` | annotate | The probe URL is the operator-configured healthz/metrics endpoint, validated at config load by `validateKubeletURL` (http/https only, host required). The `::1` fallback comes from `loopbackFallbackURL`, which only rewrites a recognized loopback host to the opposite-family loopback. No request-time input reaches these URLs. |
| G304 x3 | `ipv6_neighbor.go:576,628`, `ipv6_sysctl.go:344` | annotate | Reads of the operator-configured procfs root (default `/proc`, overridden only in tests), joined with fixed relative paths or matched by `filepath.Glob` under that root. Reading procfs is these monitors' entire purpose. |

Every `#nosec` carries a real justification after `--`. No bare suppressions.

## Verification

gosec **v2.25.0** (the version pinned by the `security-gosec` CI job), run as CI does (`-no-fail ./...`):

- **before: 70 findings**
- **after: 59 findings**

Diff is exactly the 11 in-scope findings, nothing else moved:

```
G115 pkg/monitors/network/pinger.go        3 -> 0
G204 pkg/monitors/network/ipv6_firewall.go 1 -> 0
G304 pkg/monitors/network/ipv6_neighbor.go 2 -> 0
G304 pkg/monitors/network/ipv6_sysctl.go   1 -> 0
G704 pkg/monitors/kubernetes/kubelet.go    3 -> 0
G706 pkg/monitors/kubernetes/kubelet.go    1 -> 0
```

**Note on scope:** the repo has ~59 further gosec findings (and a corresponding set of open code-scanning alerts) that predate PR #22 — G304 across `pkg/util/system.go`, `pkg/monitors/system/`, etc., plus G104/G204/G306/G402. They are untouched here to keep this PR reviewable; triaging them is a separate cleanup.

- `make build`: pass
- `make test`: pass (full suite)
- `golangci-lint` v1.64.8 (CI version) on the changed packages: clean
- `gofmt -l`: clean
- Added `TestSanitizeLogValue` covering the new sanitizer.

Task: #node-doctor-237

https://claude.ai/code/session_01Av4whriQf6KqJgRxGKQP7N