### PR TITLE
ci(release): sole image publisher, v-stripped chart image tags, visible release failures (255, 256, 257)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,12 +1,13 @@
 # GitHub Actions Workflows
 
-This directory contains every GitHub Actions workflow for Node Doctor. There are three:
+This directory contains every GitHub Actions workflow for Node Doctor. There are four:
 
 | File | Trigger | Purpose |
 |---|---|---|
-| `ci.yml` | PR to `main`, push to `main`, push of a `v*` tag | Lint, test, chart verification, build, gosec, and (on tags only) an amd64 Docker push + Grype scan |
+| `ci.yml` | PR to `main`, push to `main`, push of a `v*` tag | Lint, test, chart verification, build, gosec, and a Docker build that **never pushes** |
 | `ci-ipv6.yml` | Same, but path-filtered to network/exporter/integration code | IPv6 and dual-stack tests needing a kind cluster and `CAP_NET_RAW`. Deliberately separate so its flakes do not block `ci-success` |
-| `release.yml` | Push of a `v*` tag **only** | The actual release: multi-arch images, GitHub Release, Helm chart publish |
+| `release.yml` | Push of a `v*` tag **only** | The actual release: multi-arch images, GitHub Release, Helm chart publish. **The only workflow that publishes anything** |
+| `release-audit.yml` | Daily at 13:00 UTC, plus `workflow_dispatch` | Compares the newest `v*` tag against the chart version served by charts.support.tools; Slack on mismatch |
 
 For the full release story — what gets published where, what is signed, how to roll back — see
 [docs/release-process.md](../../docs/release-process.md). That document is the source of truth;
@@ -35,27 +36,27 @@ this one covers only what lives in this directory.
    tab. Never gates the build.
 6. **Build** — compiles `node-doctor` and `overlay-test-server`, runs `--version`, uploads the
    binary as a 7-day artifact. Needs `lint` + `test`.
-7. **Docker Build & Push** — *tags only* (`if: startsWith(github.ref, 'refs/tags/v')`), needs
-   `lint`, `test`, `build`, `security-gosec`. Builds **`linux/amd64` only** and pushes
-   `docker.io/supporttools/node-doctor:<TAG>` (the tag verbatim, i.e. **with** the `v` prefix)
-   plus `:latest`.
-8. **Grype Scan (informational)** — tag builds only, `fail-build: false`, SARIF to the Security
-   tab. Runs `anchore/scan-action` in-line rather than the org reusable workflow (see the
-   comment in `ci.yml` for why).
-9. **CI Success** — aggregate status check over `lint`, `test`, `build`, `security-gosec`,
-   `helm-chart`.
+7. **Docker Build (no push)** — runs on every PR and branch push, needs `lint`, `test`, `build`,
+   `security-gosec`. Builds `linux/amd64` with **`push: false`**. It exists to keep the
+   Dockerfile under test; it publishes nothing and cannot race `release.yml` for a tag.
+8. **CI Success** — aggregate status check over `lint`, `test`, `build`, `security-gosec`,
+   `helm-chart`, `docker`.
 
-### The tag-naming overlap with `release.yml`
+New gating jobs are wired into `ci-success`'s `needs:` rather than added as new required status
+checks — a brand-new required context leaves every already-open PR stuck on
+"Expected — waiting for status".
 
-On a `v*` tag push both workflows run and both push to `docker.io/supporttools/node-doctor`:
+### `ci.yml` publishes nothing
 
-- `ci.yml` pushes `v1.9.0` — **amd64 only**, unsigned
-- `release.yml` pushes `1.9.0` and `1.9` — **amd64 + arm64**, and cosign-signs `1.9.0`
-- both push `latest`; whichever finishes last wins, and `ci.yml` has no prerelease gate, so an
-  RC tag can leave `latest` pointing at amd64-only RC content
+It used to. A tag-gated `Docker Build & Push` job pushed
+`docker.io/supporttools/node-doctor:v<TAG>` (amd64 only, unsigned) plus an unconditional
+`:latest`, at the same time `release.yml` pushed the same repository multi-arch. With no
+ordering between the two, whichever finished last won `:latest` — so `:latest` could silently
+become amd64-only against a fleet with arm64 nodes, and an RC tag moved `:latest` regardless of
+`release.yml`'s prerelease exclusion.
 
-The Helm chart defaults `image.tag` to the `v`-prefixed form, which is the `ci.yml` one. Details
-and the workaround are in
+`release.yml` is now the sole publisher, and the Grype scan moved there with it (it scans a
+*published* image). Full story in
 [docs/release-process.md](../../docs/release-process.md#which-image-tags-actually-exist).
 
 ## `release.yml`
@@ -63,18 +64,39 @@ and the workaround are in
 Triggered only by pushing a tag matching `v*`. It runs **no tests** and does not depend on
 `ci.yml`; a tag whose tests fail still produces a complete release.
 
-Jobs: `docker`, `docker-overlay-test`, `github-release`, `helm-publish`, `release-complete`.
+Jobs: `docker`, `docker-overlay-test`, `grype-scan`, `github-release`, `helm-publish`,
+`release-complete`, `notify-failure`.
 Full breakdown in [docs/release-process.md](../../docs/release-process.md#release-overview).
+
+Two things worth knowing before you touch it:
+
+- `helm-publish` refuses to publish a chart whose default image tags do not resolve in the
+  registry (`Verify packaged chart references images that exist`). Image tags are **`v`-stripped**;
+  only `Chart.yaml` `appVersion` keeps the `v`.
+- `notify-failure` (`if: failure()`) posts to Slack via `SLACK_WEBHOOK_URL`. Without it a broken
+  release is just a red square nobody is subscribed to — which is exactly how chart publishing
+  stayed broken from `v1.8.0` to `v1.8.6`.
+
+## `release-audit.yml`
+
+Daily standing check that the newest `v*` tag has a matching chart on charts.support.tools,
+with a one-hour grace period for an in-flight release. Catches releases that were never started,
+were cancelled, or whose failure notification did not arrive. Notifies Slack on mismatch.
 
 ## Required GitHub Secrets
 
 | Secret | Used by | Required |
 |---|---|---|
-| `DOCKER_USERNAME` | `ci.yml` docker job, `release.yml` docker + docker-overlay-test jobs | Yes, for any tag build |
-| `DOCKER_PASSWORD` | same | Yes, for any tag build |
+| `DOCKER_USERNAME` | `release.yml` docker + docker-overlay-test + helm-publish jobs; `ci.yml` docker job (base-image pulls only) | Yes for releases; in CI only to dodge anonymous pull rate limits |
+| `DOCKER_PASSWORD` | same | same |
 | `BOT_TOKEN` | `release.yml` `helm-publish` — checkout of and push to `SupportTools/helm-chart` | Yes, or the chart is never published |
+| `SLACK_WEBHOOK_URL` | `release.yml` `notify-failure`, `release-audit.yml` | Yes, or release failures go unnoticed |
 | `CODECOV_TOKEN` | `ci.yml` Test job | Optional; upload is non-blocking |
-| `GITHUB_TOKEN` | `release.yml` `github-release` | Provided automatically |
+| `GITHUB_TOKEN` | `release.yml` `github-release`, `release-audit.yml` | Provided automatically |
+
+`HELM_CHART_PAT` is an org secret that looks like it belongs here and **does not** — no
+node-doctor workflow references it. See
+[docs/release-process.md](../../docs/release-process.md#helm_chart_pat-is-not-this-repos-credential).
 
 The registry is **Docker Hub** (`docker.io/supporttools`), not Harbor. There are no
 `HARBOR_USERNAME` / `HARBOR_PASSWORD` secrets in use; if they exist in repository settings they
@@ -92,18 +114,20 @@ on a single image tag.
 ## Triggering builds
 
 ### Pull request
-Opens lint, helm-chart, test, pinger-icmp, gosec and build jobs. No images are pushed.
+Opens lint, helm-chart, test, pinger-icmp, gosec, build and docker jobs. No images are pushed —
+the docker job builds with `push: false`.
 
 ### Push to `main`
-Same set. Still no images — the docker job is gated on `refs/tags/v`.
+Same set. Still no images.
 
 ### Release
 ```bash
 git tag -a v1.9.0 -m "Release v1.9.0"
 git push origin v1.9.0
 ```
-Runs `ci.yml` (full pipeline + amd64 image + Grype) **and** `release.yml` (multi-arch images,
-GitHub Release, Helm chart) in parallel. Watch both:
+Runs `ci.yml` (full pipeline, still publishing nothing) **and** `release.yml` (multi-arch
+images, Grype, GitHub Release, Helm chart) in parallel. `release.yml` is the one that matters
+for artifacts; `ci.yml` is the one that tells you whether the commit was any good. Watch both:
 
 ```bash
 gh run list --workflow=ci.yml --branch v1.9.0
@@ -134,11 +158,17 @@ coverage-check` uses a stricter local threshold of 80%, so passing locally impli
 **Helm Chart job failure** — you edited `helm/node-doctor/values.yaml` or `Chart.yaml` directly,
 or edited a `*.template` without regenerating. Run `make helm-generate` and commit both files.
 
-**Docker job skipped** — expected on PRs and `main` pushes; it only runs on `v*` tags.
+**Docker job failed** — the Dockerfile does not build. It publishes nothing either way, so this
+never affects the registry; it does block `ci-success`, and it should, because the same
+Dockerfile is what `release.yml` builds from.
 
-**Docker job failed on a tag** — the `v`-prefixed image tag was not pushed. The multi-arch image
-from `release.yml` still exists under the un-prefixed tag. See
+**`docker pull ...:v1.9.0` says not found** — expected. Image tags are `v`-stripped; pull
+`1.9.0`. See
 [docs/release-process.md](../../docs/release-process.md#docker-pull-supporttoolsnode-doctorv190-says-not-found).
+
+**A release published images but no chart** — check `helm-publish` in that `release.yml` run,
+and check Slack for the `notify-failure` message. See
+[docs/release-process.md](../../docs/release-process.md#releaseyml-succeeded-but-the-chart-is-not-on-chartssupporttools).
 
 **Secret errors** — check names against the table above; the most common cause is a workflow
 looking for `DOCKER_*` while only `HARBOR_*` are configured.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,17 +234,26 @@ jobs:
           path: bin/node-doctor
           retention-days: 7
 
-  # Docker build and push - only on tags
+  # Docker image build - VALIDATION ONLY, never pushes.
+  #
+  # This job used to be gated on `startsWith(github.ref, 'refs/tags/v')` and pushed both
+  # ${TAG} and, unconditionally, `latest` — linux/amd64 only. release.yml pushes the same
+  # repository (docker.io/supporttools/node-doctor) on the same tag event, multi-arch, and
+  # deliberately withholds `latest` from rc/beta/alpha tags. With no ordering between the
+  # two workflows, whichever finished last won `:latest`, so `:latest` could silently become
+  # amd64-only (the fleet has arm64 nodes -> exec format error), and an -rc tag could move
+  # `:latest` anyway, defeating release.yml's exclusion.
+  #
+  # release.yml is now the SOLE publisher of container images. This job keeps the Dockerfile
+  # under test on every PR/branch push (earlier than before, when it only built on tags) but
+  # builds with push:false so it can never race for a tag. The grype scan that used to live
+  # here needs a *published* image and therefore moved to release.yml.
   docker:
-    name: Docker Build & Push
+    name: Docker Build (no push)
     runs-on: ubuntu-latest
     needs: [lint, test, build, security-gosec]
-    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
-      security-events: write
       contents: read
-    outputs:
-      tag: ${{ steps.tag.outputs.TAG }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -252,37 +261,36 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
+      # Authenticated base-image pulls avoid anonymous Docker Hub rate limits.
+      # Skipped for fork PRs, which have no access to secrets; the build still works
+      # anonymously there.
+      - name: Log in to Docker Hub (base image pulls)
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Extract tag name
-        id: tag
-        run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-
       - name: Build metadata
         id: meta
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          VERSION=${{ steps.tag.outputs.TAG }}
-          GIT_COMMIT=$(git rev-parse HEAD)
-          BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          # Validation build only - this VERSION never reaches a published image.
+          {
+            echo "VERSION=ci-$(printf '%s' "$REF_NAME" | tr -cd 'A-Za-z0-9._-')"
+            echo "GIT_COMMIT=$(git rev-parse HEAD)"
+            echo "BUILD_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          } >> "$GITHUB_OUTPUT"
 
-          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
-          echo "GIT_COMMIT=${GIT_COMMIT}" >> $GITHUB_OUTPUT
-          echo "BUILD_TIME=${BUILD_TIME}" >> $GITHUB_OUTPUT
-
-      - name: Build and push Docker image
+      - name: Build Docker image (no push)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/node-doctor:${{ steps.tag.outputs.TAG }}
-            ${{ env.REGISTRY }}/node-doctor:latest
+          push: false
+          tags: ${{ env.REGISTRY }}/node-doctor:ci-${{ github.sha }}
           build-args: |
             VERSION=${{ steps.meta.outputs.VERSION }}
             GIT_COMMIT=${{ steps.meta.outputs.GIT_COMMIT }}
@@ -290,47 +298,16 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  # Grype vulnerability scan - INFORMATIONAL (SARIF/report only, no build gate).
-  # Replaces the former Trivy scan. Uses anchore/scan-action (grype engine) IN-LINE
-  # rather than the org reusable grype-scan.yml for two reasons:
-  #   1. ci.yml is pull_request-triggered, and a private-repo reusable `uses:` fails to
-  #      resolve at workflow-LOAD time on pull_request events, which fails the ENTIRE run
-  #      at startup (0 jobs). A job-level `if:` does not help (resolution precedes `if`).
-  #   2. node-doctor publishes images to Docker Hub (docker.io/supporttools), not Harbor,
-  #      so the reusable workflow's keyless Harbor pull is the wrong mechanism anyway.
-  # anchore/scan-action uses the public grype vuln DB (not the org's self-hosted air-gapped
-  # mirror) — acceptable here since the scanned image is public on Docker Hub.
-  # Runs only on tag builds, matching the `docker` job that produces the image.
-  grype-scan:
-    name: Grype Scan (informational)
-    runs-on: ubuntu-latest
-    needs: [docker]
-    if: startsWith(github.ref, 'refs/tags/v')
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - name: Grype scan (anchore/scan-action)
-        id: grype
-        uses: anchore/scan-action@v6
-        with:
-          image: docker.io/supporttools/node-doctor:${{ needs.docker.outputs.tag }}
-          fail-build: false
-          severity-cutoff: high
-          output-format: sarif
-      - name: Upload SARIF to GitHub Security
-        if: always()
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: ${{ steps.grype.outputs.sarif }}
-          category: grype
-
   # Summary job - provides overall status
+  #
+  # New gating jobs are wired in here rather than added as new required status checks:
+  # a brand-new required context leaves every already-open PR stuck on
+  # "Expected — waiting for status". `CI Success` is already required, so extending its
+  # `needs:` gates the new job without touching branch protection.
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, test, build, security-gosec, helm-chart]
+    needs: [lint, test, build, security-gosec, helm-chart, docker]
     if: always()
     steps:
       - name: Check job results
@@ -339,7 +316,8 @@ jobs:
              [[ "${{ needs.test.result }}" != "success" ]] || \
              [[ "${{ needs.build.result }}" != "success" ]] || \
              [[ "${{ needs.security-gosec.result }}" != "success" ]] || \
-             [[ "${{ needs.helm-chart.result }}" != "success" ]]; then
+             [[ "${{ needs.helm-chart.result }}" != "success" ]] || \
+             [[ "${{ needs.docker.result }}" != "success" ]]; then
             echo "One or more CI jobs failed"
             exit 1
           fi

--- a/.github/workflows/release-audit.yml
+++ b/.github/workflows/release-audit.yml
@@ -1,0 +1,131 @@
+name: Release Audit
+
+# Catches the whole class of "a release silently did not ship", not just the one cause.
+#
+# release.yml already hard-fails when a chart does not appear on charts.support.tools, and
+# notify-failure now pushes that failure to Slack. Both only fire while a release run is
+# in flight. This audit is the standing check: it compares the newest git tag against what
+# charts.support.tools actually serves, so a gap is caught even if the release run was
+# never started, was cancelled, was re-run into a green state, or the notification itself
+# failed to deliver. The six-month outage this repo just came out of would have been
+# caught the next morning.
+#
+# Scope note: this audits node-doctor only, using the default GITHUB_TOKEN and the public
+# chart index. Extending it across the other SupportTools chart-publishing repos needs a
+# decision on where it lives and which credential enumerates them — see PR discussion.
+
+on:
+  schedule:
+    # 13:00 UTC daily (~08:00 US Central), so a broken release surfaces the next morning.
+    - cron: "0 13 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  tag-vs-chart:
+    name: Newest tag has a published chart
+    runs-on: ubuntu-latest
+    outputs:
+      detail: ${{ steps.audit.outputs.detail }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Compare newest tag against published chart
+        id: audit
+        env:
+          # How long after a tag is created before its chart is expected to exist.
+          # Covers a release run that is still in flight.
+          GRACE_SECONDS: "3600"
+        run: |
+          set -euo pipefail
+
+          TAG_LINE="$(
+            git for-each-ref --sort=-creatordate \
+              --format='%(refname:short) %(creatordate:unix)' \
+              'refs/tags/v*' | head -n 1
+          )"
+
+          if [ -z "$TAG_LINE" ]; then
+            echo "No v* tags found; nothing to audit."
+            exit 0
+          fi
+
+          TAG="${TAG_LINE%% *}"
+          TAG_TIME="${TAG_LINE##* }"
+
+          # Tag names are attacker-influencable by anyone who can push a tag, so pin the
+          # value to a known-safe charset before it reaches any command line.
+          SAFE_TAG="$(printf '%s' "$TAG" | tr -cd 'A-Za-z0-9._+-')"
+          if [ "$SAFE_TAG" != "$TAG" ]; then
+            echo "::error::Newest tag contains unexpected characters: refusing to audit"
+            exit 1
+          fi
+
+          AGE=$(( $(date -u +%s) - TAG_TIME ))
+          echo "Newest tag: ${SAFE_TAG} (age ${AGE}s)"
+
+          if [ "$AGE" -lt "$GRACE_SECONDS" ]; then
+            echo "Tag is younger than the ${GRACE_SECONDS}s grace period; release may still be running."
+            exit 0
+          fi
+
+          CHART_VERSION="${SAFE_TAG#v}"
+          helm repo add charts https://charts.support.tools/ >/dev/null
+          helm repo update >/dev/null
+
+          if helm search repo charts/node-doctor --versions -o json \
+              | jq -e --arg v "$CHART_VERSION" 'any(.[]; .version == $v)' >/dev/null; then
+            echo "✅ Chart node-doctor ${CHART_VERSION} is published."
+            echo "- ✅ Newest tag \`${SAFE_TAG}\` has chart \`${CHART_VERSION}\` on charts.support.tools" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          LATEST_CHART="$(helm search repo charts/node-doctor -o json 2>/dev/null \
+            | jq -r '.[0].version // "none"' || echo "unknown")"
+          {
+            echo "## ❌ Release audit failed"
+            echo ""
+            echo "Newest git tag \`${SAFE_TAG}\` expects chart version \`${CHART_VERSION}\`,"
+            echo "but charts.support.tools serves \`${LATEST_CHART}\`."
+            echo ""
+            echo "The tag, the GitHub release and the container image can all exist while the"
+            echo "chart was never published. Check the release run for \`${SAFE_TAG}\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "detail=tag ${SAFE_TAG} expects chart ${CHART_VERSION}, repo serves ${LATEST_CHART}" >> "$GITHUB_OUTPUT"
+          echo "::error::Chart ${CHART_VERSION} for tag ${SAFE_TAG} is not published (repo serves ${LATEST_CHART})"
+          exit 1
+
+  notify-failure:
+    name: Notify Audit Failure
+    runs-on: ubuntu-latest
+    needs: [tag-vs-chart]
+    if: failure()
+    steps:
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "❌ node-doctor release audit failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "❌ *node-doctor* release audit *FAILED*\n\nThe newest git tag has no matching chart on charts.support.tools.\n\n`${{ needs.tag-vs-chart.outputs.detail }}`\n\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Run>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/release-audit.yml
+++ b/.github/workflows/release-audit.yml
@@ -81,15 +81,19 @@ jobs:
           helm repo add charts https://charts.support.tools/ >/dev/null
           helm repo update >/dev/null
 
+          # `helm search repo` matches on substring, so `charts/node-doctor` would also
+          # return e.g. `charts/node-doctor-overlay-test`. Match the name exactly.
           if helm search repo charts/node-doctor --versions -o json \
-              | jq -e --arg v "$CHART_VERSION" 'any(.[]; .version == $v)' >/dev/null; then
+              | jq -e --arg v "$CHART_VERSION" \
+                  'any(.[]; .name == "charts/node-doctor" and .version == $v)' >/dev/null; then
             echo "✅ Chart node-doctor ${CHART_VERSION} is published."
             echo "- ✅ Newest tag \`${SAFE_TAG}\` has chart \`${CHART_VERSION}\` on charts.support.tools" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
-          LATEST_CHART="$(helm search repo charts/node-doctor -o json 2>/dev/null \
-            | jq -r '.[0].version // "none"' || echo "unknown")"
+          LATEST_CHART="$(helm search repo charts/node-doctor --versions -o json 2>/dev/null \
+            | jq -r '[.[] | select(.name == "charts/node-doctor")][0].version // "none"' \
+            || echo "unknown")"
           {
             echo "## ❌ Release audit failed"
             echo ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,35 @@ env:
   IMAGE_NAME: supporttools/node-doctor
 
 jobs:
-  # Build and push Docker images
+  # Build and push Docker images.
+  #
+  # This is the SOLE publisher of docker.io/supporttools/node-doctor. ci.yml used to push
+  # the same repository on the same tag event (amd64-only, and it moved `latest`
+  # unconditionally, including for rc/beta/alpha tags); its docker job is now a
+  # push:false validation build. Do not reintroduce a push from any other workflow.
   docker:
     name: Build & Push Docker Images
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+
+      # A git tag name may legally contain shell metacharacters, so it is never
+      # interpolated straight into a `run:` block. Pass it through env, quote it, and
+      # strip it to a known-safe charset once here; downstream steps use the output.
+      - name: Resolve release version
+        id: version
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          RAW="$(printf '%s' "$REF_NAME" | tr -cd 'A-Za-z0-9._+-')"
+          if [ "$RAW" != "$REF_NAME" ]; then
+            echo "::error::Tag name contains unexpected characters; refusing to release"
+            exit 1
+          fi
+          echo "version=${RAW#v}" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -70,33 +92,37 @@ jobs:
       - name: Sign Docker image
         env:
           COSIGN_EXPERIMENTAL: 1
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
         run: |
-          # Extract version without 'v' prefix (to match docker metadata output)
-          VERSION="${{ github.ref_name }}"
-          VERSION="${VERSION#v}"
           echo "Signing Docker image with cosign (keyless)..."
-          echo "Tag: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}"
-          cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}
+          echo "Tag: ${IMAGE_REF}"
+          cosign sign --yes "${IMAGE_REF}"
           echo "✅ Docker image signed"
 
       - name: Generate Docker summary
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+          IMAGE_REPO: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         run: |
-          echo "## 🐳 Docker Images" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Tag:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Images Published" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Platforms:** linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Pull Command" >> $GITHUB_STEP_SUMMARY
-          echo '```bash' >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## 🐳 Docker Images"
+            echo ""
+            echo "**Tag:** ${REF_NAME}"
+            echo ""
+            echo "### Images Published"
+            echo ""
+            echo '```'
+            echo "${IMAGE_TAGS}"
+            echo '```'
+            echo ""
+            echo "**Platforms:** linux/amd64, linux/arm64"
+            echo ""
+            echo "### Pull Command"
+            echo '```bash'
+            echo "docker pull ${IMAGE_REPO}:${REF_NAME}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # Build and push overlay-test Docker image (multi-arch)
   docker-overlay-test:
@@ -231,18 +257,25 @@ jobs:
 
       - name: Determine Chart Version
         id: get-chart-version
+        env:
+          # Sanitized in the `docker` job; carried through instead of re-deriving from
+          # github.ref_name inside a shell.
+          CHART_VERSION: ${{ needs.docker.outputs.version }}
         run: |
-          # Remove 'v' prefix for Helm chart version
-          VERSION="${{ github.ref_name }}"
-          VERSION="${VERSION#v}"
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          if [ -z "$CHART_VERSION" ]; then
+            echo "::error::Chart version was not resolved by the docker job"
+            exit 1
+          fi
+          echo "version=${CHART_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Prepare Helm chart files
+        env:
+          CHART_VERSION: ${{ steps.get-chart-version.outputs.version }}
+          APP_VERSION: v${{ steps.get-chart-version.outputs.version }}
+          IMAGE_TAG: v${{ steps.get-chart-version.outputs.version }}
         run: |
           rm -f helm/node-doctor/Chart.yaml helm/node-doctor/values.yaml
-          export CHART_VERSION="${{ steps.get-chart-version.outputs.version }}"
-          export APP_VERSION="${{ github.ref_name }}"
-          export IMAGE_TAG="${{ github.ref_name }}"
+          export CHART_VERSION APP_VERSION IMAGE_TAG
           envsubst < helm/node-doctor/Chart.yaml.template > helm/node-doctor/Chart.yaml
           envsubst < helm/node-doctor/values.yaml.template > helm/node-doctor/values.yaml
           echo "=== Chart.yaml ==="
@@ -274,50 +307,89 @@ jobs:
           git config --global user.name "GitHub Action"
 
       - name: Update Helm repository
+        env:
+          CHART_VERSION: ${{ steps.get-chart-version.outputs.version }}
         run: |
           cp helm/repo/node-doctor-*.tgz helm-chart/
           cd helm-chart
           helm repo index . --url https://charts.support.tools/
           git add .
-          git commit -m "Update Node Doctor Helm chart ${{ steps.get-chart-version.outputs.version }}"
+          git commit -m "Update Node Doctor Helm chart ${CHART_VERSION}"
           git push
 
       - name: Verify Chart Availability
+        env:
+          CHART_VERSION: ${{ steps.get-chart-version.outputs.version }}
         run: |
           helm repo add charts https://charts.support.tools/
           MAX_TRIES=30
           SLEEP_TIME=10
           COUNTER=0
-          CHART_VERSION="${{ steps.get-chart-version.outputs.version }}"
 
           while [ $COUNTER -lt $MAX_TRIES ]; do
             helm repo update
-            if helm search repo charts/node-doctor --version $CHART_VERSION | grep -q $CHART_VERSION; then
+            if helm search repo charts/node-doctor --version "$CHART_VERSION" | grep -qF -- "$CHART_VERSION"; then
               echo "✅ Chart node-doctor version $CHART_VERSION found in repository"
               exit 0
             fi
             echo "Waiting for chart to become available... (Attempt $((COUNTER+1))/$MAX_TRIES)"
             sleep $SLEEP_TIME
-            let COUNTER=COUNTER+1
+            COUNTER=$((COUNTER + 1))
           done
 
           echo "❌ Chart did not become available within the timeout period"
           exit 1
 
       - name: Add Helm chart to release summary
+        env:
+          CHART_VERSION: ${{ steps.get-chart-version.outputs.version }}
         run: |
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 📦 Helm Chart" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Chart Version:** ${{ steps.get-chart-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Repository:** https://charts.support.tools/" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Install with:" >> $GITHUB_STEP_SUMMARY
-          echo '```bash' >> $GITHUB_STEP_SUMMARY
-          echo "helm repo add supporttools https://charts.support.tools" >> $GITHUB_STEP_SUMMARY
-          echo "helm repo update" >> $GITHUB_STEP_SUMMARY
-          echo "helm install node-doctor supporttools/node-doctor --namespace node-doctor --create-namespace" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          {
+            echo ""
+            echo "### 📦 Helm Chart"
+            echo ""
+            echo "- **Chart Version:** ${CHART_VERSION}"
+            echo "- **Repository:** https://charts.support.tools/"
+            echo ""
+            echo "Install with:"
+            echo '```bash'
+            echo "helm repo add supporttools https://charts.support.tools"
+            echo "helm repo update"
+            echo "helm install node-doctor supporttools/node-doctor --namespace node-doctor --create-namespace"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Grype vulnerability scan - INFORMATIONAL (SARIF/report only, no release gate).
+  #
+  # Moved here from ci.yml: it scans a *published* image, and the only workflow that
+  # publishes images is this one. Uses anchore/scan-action (grype engine) IN-LINE rather
+  # than the org reusable grype-scan.yml because node-doctor publishes to Docker Hub
+  # (docker.io/supporttools), not Harbor, so the reusable workflow's keyless Harbor pull is
+  # the wrong mechanism. anchore/scan-action uses the public grype vuln DB rather than the
+  # org's self-hosted air-gapped mirror — acceptable, the scanned image is public.
+  grype-scan:
+    name: Grype Scan (informational)
+    runs-on: ubuntu-latest
+    needs: [docker]
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Grype scan (anchore/scan-action)
+        id: grype
+        uses: anchore/scan-action@v6
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.docker.outputs.version }}
+          fail-build: false
+          severity-cutoff: high
+          output-format: sarif
+      - name: Upload SARIF to GitHub Security
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ steps.grype.outputs.sarif }}
+          category: grype
 
   # Summary job
   release-complete:
@@ -327,6 +399,9 @@ jobs:
     if: always()
     steps:
       - name: Check release status
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
         run: |
           if [[ "${{ needs.docker.result }}" != "success" ]]; then
             echo "❌ Docker build job failed"
@@ -344,11 +419,78 @@ jobs:
             echo "❌ Helm publish job failed"
             exit 1
           fi
-          echo "✅ Release ${{ github.ref_name }} completed successfully!"
+          echo "✅ Release ${REF_NAME} completed successfully!"
           echo ""
           echo "Next steps:"
-          echo "1. Verify release: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}"
-          echo "2. Test Docker image: docker pull supporttools/node-doctor:${{ github.ref_name }}"
+          echo "1. Verify release: https://github.com/${REPO}/releases/tag/${REF_NAME}"
+          echo "2. Test Docker image: docker pull supporttools/node-doctor:${REF_NAME}"
           echo "3. Test Helm chart: helm install node-doctor supporttools/node-doctor"
           echo "4. Update documentation if needed"
           echo "5. Announce release to users"
+
+  # Failure notification.
+  #
+  # Why this job exists: a red release run is not, by itself, a signal anyone receives.
+  # `helm-publish` has hard-failed on "Verify Chart Availability" for six months across
+  # eight repos — the workflow was doing exactly what it was told and going red on purpose
+  # — and nobody noticed, because nothing pushed that failure anywhere a human looks.
+  # Any future fix that makes releases fail correctly is worthless without this job.
+  #
+  # Mechanism is the org's established one: slackapi/slack-github-action posting to the
+  # org secret SLACK_WEBHOOK_URL (visibility: all), same as SupportTools/support-decoder
+  # cd.yml and SupportTools/website cloudflare-workers-notifications.yml.
+  notify-failure:
+    name: Notify Release Failure
+    runs-on: ubuntu-latest
+    needs: [docker, docker-overlay-test, github-release, helm-publish, grype-scan, release-complete]
+    if: failure()
+    steps:
+      # A tag name may legally contain characters that would break out of the JSON
+      # payload below, and github.ref_name is attacker-influencable by anyone who can
+      # push a tag. Strip it to a safe charset before it is interpolated anywhere.
+      - name: Build notification context
+        id: ctx
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          echo "ref=$(printf '%s' "$REF_NAME" | tr -cd 'A-Za-z0-9._+-')" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize failure in the run summary
+        env:
+          REF: ${{ steps.ctx.outputs.ref }}
+        run: |
+          {
+            echo "## ❌ Release ${REF} FAILED"
+            echo ""
+            echo "| Job | Result |"
+            echo "| --- | --- |"
+            echo "| Docker images | ${{ needs.docker.result }} |"
+            echo "| Overlay test image | ${{ needs.docker-overlay-test.result }} |"
+            echo "| GitHub release | ${{ needs.github-release.result }} |"
+            echo "| Helm chart publish | ${{ needs.helm-publish.result }} |"
+            echo "| Grype scan | ${{ needs.grype-scan.result }} |"
+            echo ""
+            echo "A failed \`helm-publish\` means **the chart was not published** — the tag,"
+            echo "the GitHub release and the container image can all exist while"
+            echo "charts.support.tools still serves the previous version."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "❌ node-doctor release ${{ steps.ctx.outputs.ref }} FAILED",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "❌ *node-doctor* release *${{ steps.ctx.outputs.ref }}* *FAILED*\n\n*Docker images:* `${{ needs.docker.result }}`\n*Overlay test image:* `${{ needs.docker-overlay-test.result }}`\n*GitHub release:* `${{ needs.github-release.result }}`\n*Helm chart publish:* `${{ needs.helm-publish.result }}`\n\nA failed chart publish means charts.support.tools still serves the previous version.\n\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Run>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,10 +236,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Helm Chart Publishing
+  #
+  # Depends on docker-overlay-test as well as docker: the chart's default values reference
+  # BOTH images, and the post-package guard below asserts those references actually resolve
+  # in the registry. That assertion is only meaningful once both images have been pushed.
   helm-publish:
     name: Publish Helm Chart
     runs-on: ubuntu-latest
-    needs: docker
+    needs: [docker, docker-overlay-test]
     outputs:
       chart-version: ${{ steps.get-chart-version.outputs.version }}
 
@@ -268,11 +272,27 @@ jobs:
           fi
           echo "version=${CHART_VERSION}" >> "$GITHUB_OUTPUT"
 
+      # IMAGE_TAG MUST be v-stripped. Do not "fix" it back to github.ref_name for
+      # consistency with APP_VERSION — they are deliberately different.
+      #
+      # docker/metadata-action in the `docker` job publishes
+      # `type=semver,pattern={{version}}`, which strips the leading v: the image lands on
+      # Docker Hub as `1.8.7`, never `v1.8.7`. values.yaml.template feeds ${IMAGE_TAG} into
+      # BOTH image.tag and overlayTest.image.tag, so when IMAGE_TAG carried the v, every
+      # published chart defaulted to an image tag that was never pushed —
+      # `helm install supporttools/node-doctor` with default values gave ImagePullBackOff
+      # on both DaemonSets. node-doctor-overlay-test has never had a v-prefixed tag for any
+      # version (release.yml is its only publisher). The main image's v-prefixed tag existed
+      # only when ci.yml's duplicate docker job happened to win the race — and that job no
+      # longer pushes, so this fix has to ship with the sole-publisher change, not after it.
+      #
+      # APP_VERSION keeps the v: that is Chart.yaml appVersion, a human-facing release name,
+      # not a registry reference.
       - name: Prepare Helm chart files
         env:
           CHART_VERSION: ${{ steps.get-chart-version.outputs.version }}
           APP_VERSION: v${{ steps.get-chart-version.outputs.version }}
-          IMAGE_TAG: v${{ steps.get-chart-version.outputs.version }}
+          IMAGE_TAG: ${{ steps.get-chart-version.outputs.version }}
         run: |
           rm -f helm/node-doctor/Chart.yaml helm/node-doctor/values.yaml
           export CHART_VERSION APP_VERSION IMAGE_TAG
@@ -293,6 +313,73 @@ jobs:
           mkdir -p helm/repo
           helm package helm/node-doctor --destination helm/repo
           ls -la helm/repo/
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # Regression guard for the v-prefix bug fixed above.
+      #
+      # Reads the image references back out of the PACKAGED tarball — not the working tree —
+      # so it validates exactly what gets published, and asserts every one of them resolves
+      # in the registry. A chart whose default values point at a tag that was never pushed
+      # is a broken chart, and it must not reach charts.support.tools.
+      #
+      # This catches the whole class, not just the v-prefix: any future drift between what
+      # the `docker` jobs push and what the chart defaults to fails the release here.
+      - name: Verify packaged chart references images that exist
+        run: |
+          set -euo pipefail
+
+          TGZ="$(ls helm/repo/node-doctor-*.tgz)"
+          rm -rf /tmp/chart-verify && mkdir -p /tmp/chart-verify
+          tar -xzf "$TGZ" -C /tmp/chart-verify
+
+          # Emit "<repository>:<tag>" for each image the packaged defaults reference.
+          python3 - <<'PY' > /tmp/chart-image-refs.txt
+          import sys, yaml
+          with open('/tmp/chart-verify/node-doctor/values.yaml') as fh:
+              v = yaml.safe_load(fh)
+          refs = []
+          for path in (('image',), ('overlayTest', 'image')):
+              node = v
+              for key in path:
+                  node = (node or {}).get(key)
+              if not node:
+                  continue
+              repo, tag = node.get('repository'), node.get('tag')
+              if not repo or not tag:
+                  print(f"missing repository/tag under {'.'.join(path)}", file=sys.stderr)
+                  sys.exit(1)
+              refs.append(f"{repo}:{tag}")
+          if not refs:
+              print("no image references found in packaged values.yaml", file=sys.stderr)
+              sys.exit(1)
+          print('\n'.join(refs))
+          PY
+
+          echo "Packaged chart references:"
+          cat /tmp/chart-image-refs.txt
+
+          FAILED=0
+          while read -r REF; do
+            [ -n "$REF" ] || continue
+            if docker manifest inspect "docker.io/${REF}" >/dev/null 2>&1; then
+              echo "✅ ${REF} exists"
+            else
+              echo "::error::Packaged chart defaults to ${REF}, which does not exist in the registry"
+              FAILED=1
+            fi
+          done < /tmp/chart-image-refs.txt
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo "❌ Refusing to publish a chart whose default image tags cannot be pulled."
+            echo "   docker/metadata-action publishes v-stripped semver tags, so IMAGE_TAG"
+            echo "   in 'Prepare Helm chart files' must be v-stripped too."
+            exit 1
+          fi
 
       - name: Checkout helm-chart repository
         uses: actions/checkout@v5

--- a/Makefile
+++ b/Makefile
@@ -402,9 +402,15 @@ push-all-images: push-node-doctor-image push-overlay-test-server-image
 #
 # These placeholders stand in for the tag-derived values CI injects; they exist only so
 # the committed copies are byte-reproducible and diffable.
+#
+# IMAGE_TAG is v-STRIPPED and APP_VERSION is not. That asymmetry is deliberate and mirrors
+# release.yml: docker/metadata-action publishes `type=semver,pattern={{version}}`, so images
+# land on Docker Hub as `1.8.7`, never `v1.8.7`, while Chart.yaml appVersion keeps the v as a
+# human-facing release name. Keep these placeholders matching release.yml or the committed
+# values.yaml stops being an accurate model of the shipped chart.
 HELM_PLACEHOLDER_CHART_VERSION := 1.0.0
 HELM_PLACEHOLDER_APP_VERSION   := v1.0.0
-HELM_PLACEHOLDER_IMAGE_TAG     := v1.0.0
+HELM_PLACEHOLDER_IMAGE_TAG     := 1.0.0
 
 # Renders the templates the same way release.yml does (bare envsubst).
 define helm_render

--- a/Makefile
+++ b/Makefile
@@ -529,7 +529,15 @@ deploy-prd-kubectl: check-kubectl
 	@KUBECONFIG=$(KUBECONFIG_PRD) kubectl rollout status daemonset/node-doctor -n $(NAMESPACE_PRD) --timeout=5m
 	@$(call print_success,Deployed to production cluster $(KUBECTL_CONTEXT_PRD))
 
-# Build and push RC release to Harbor and deploy to a1-ops-prd cluster
+# Build and push RC release to $(REGISTRY) and deploy to a1-ops-prd cluster.
+#
+# This target deliberately does NOT tag :latest. It used to, which meant a workstation
+# build of a *release candidate* could overwrite the :latest that release.yml publishes
+# only for non-rc tags. Only .github/workflows/release.yml moves :latest.
+#
+# The git steps below are also not `|| true`: a failed commit/tag/push used to be
+# swallowed, leaving an image pushed and a cluster deployed from a revision that was
+# never tagged or pushed anywhere.
 bump-rc: validate-pipeline-local increment-rc-version
 	@$(call print_status,Building RC release: $(RC_VERSION))
 	@$(call print_status,Registry: $(REGISTRY)/$(PROJECT_NAME))
@@ -542,7 +550,6 @@ bump-rc: validate-pipeline-local increment-rc-version
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		--build-arg BUILD_TIME=$(BUILD_TIME) \
 		-t $(REGISTRY)/$(PROJECT_NAME):$(RC_VERSION) \
-		-t $(REGISTRY)/$(PROJECT_NAME):latest \
 		-f Dockerfile \
 		--push \
 		.
@@ -556,12 +563,12 @@ bump-rc: validate-pipeline-local increment-rc-version
 	@echo ""
 	@$(call print_status,Committing RC release...)
 	@git add $(RC_VERSION_FILE) deployment/daemonset.yaml
-	@git commit -m "bump-rc: Release candidate $(RC_VERSION) deployed to $(KUBECTL_CONTEXT_PRD)" || true
-	@git tag -a $(RC_VERSION) -m "Release candidate $(RC_VERSION)" || true
-	@git push origin main --tags || true
+	@git commit -m "bump-rc: Release candidate $(RC_VERSION) deployed to $(KUBECTL_CONTEXT_PRD)"
+	@git tag -a $(RC_VERSION) -m "Release candidate $(RC_VERSION)"
+	@git push origin main --tags
 	@echo ""
 	@echo "🎉 RC Release $(RC_VERSION) complete!"
-	@echo "   - Built and pushed to Harbor"
+	@echo "   - Built and pushed to $(REGISTRY)/$(PROJECT_NAME):$(RC_VERSION)"
 	@echo "   - Deployed to $(KUBECTL_CONTEXT_PRD) cluster"
 	@echo "   - Tagged as $(RC_VERSION)"
 	@echo ""
@@ -675,7 +682,7 @@ help:
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@echo ""
 	@echo "  make bump                  Bump version and trigger CI/CD"
-	@echo "  make bump-rc               Build RC, push to Harbor, deploy to a1-ops-prd"
+	@echo "  make bump-rc               Build RC, push to $(REGISTRY), deploy to a1-ops-prd"
 	@echo "  make bump-with-monitoring  Bump and watch deployment"
 	@echo "  make deploy-dev            Deploy to development"
 	@echo "  make deploy-stg            Deploy to staging"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -10,6 +10,7 @@ in the same PR.
 ## Table of Contents
 
 - [Release Overview](#release-overview)
+- [Release credentials](#release-credentials)
 - [Which Helm chart files actually ship](#which-helm-chart-files-actually-ship)
 - [Which image tags actually exist](#which-image-tags-actually-exist)
 - [Version Numbering](#version-numbering)
@@ -30,27 +31,39 @@ manual dispatch, no branch trigger, no scheduled release.
 ```
 git push origin v1.9.0
      |
-     +--> .github/workflows/release.yml  (on: push: tags: v*)
+     +--> .github/workflows/release.yml  (on: push: tags: v*)   <-- publishes EVERYTHING
      |      docker                -> docker.io/supporttools/node-doctor            (amd64+arm64)
      |      docker-overlay-test   -> docker.io/supporttools/node-doctor-overlay-test (amd64+arm64)
+     |      grype-scan            -> SARIF -> GitHub Security (informational)
      |      github-release        -> GitHub Release + deployment/{rbac,daemonset}.yaml
      |      helm-publish          -> SupportTools/helm-chart repo -> https://charts.support.tools
      |      release-complete      -> fails the run if any of the above failed
+     |      notify-failure        -> Slack, if anything above failed
      |
      +--> .github/workflows/ci.yml       (also fires on tags: v*)
-            lint / test / build / gosec / helm-chart
-            docker (tag builds only)  -> docker.io/supporttools/node-doctor:v<TAG> and :latest
-                                         **linux/amd64 only**
-            grype-scan (informational)
+            lint / test / build / gosec / helm-chart / docker / ci-success
+            **publishes nothing** — its docker job builds with push:false
+
+daily 13:00 UTC
+     +--> .github/workflows/release-audit.yml
+            newest git tag vs newest chart on charts.support.tools -> Slack on mismatch
 ```
 
-The two workflows are **independent**. `release.yml` does not run tests and does not wait for
-`ci.yml`. A tag whose test suite fails still produces a complete release.
+**`release.yml` is the sole publisher of container images.** `ci.yml` used to have a
+tag-gated `docker` job that pushed the same repository on the same tag event, with no ordering
+between the two — see [Which image tags actually exist](#which-image-tags-actually-exist) for
+what that cost. Its `docker` job now builds with `push: false` on every PR and branch push, so
+the Dockerfile is validated earlier than it used to be and can never race for a tag. Nothing
+outside `release.yml` may move `:latest`.
+
+The two workflows are still **independent**. `release.yml` does not run tests and does not wait
+for `ci.yml`. A tag whose test suite fails still produces a complete release.
 
 > This is not hypothetical. On tag `v1.8.7` the `ci.yml` `Test` job failed, which skipped
-> `Build` and `Docker Build & Push` — while `release.yml` succeeded and published images, the
-> GitHub Release, and Helm chart `1.8.7`. See
-> [Which image tags actually exist](#which-image-tags-actually-exist) for the consequence.
+> `Build` and the then-existing `Docker Build & Push` job — while `release.yml` succeeded and
+> published images, the GitHub Release, and Helm chart `1.8.7`. The *tag-naming* consequence
+> that had is now fixed; the underlying "a release does not depend on tests passing" property
+> is not. Cutting a tag on a red commit is still entirely your own foot.
 
 **Registry**: Docker Hub (`docker.io/supporttools`). Not Harbor. `release.yml:15`, `ci.yml:15`
 and `Makefile:39` all agree on this.
@@ -59,15 +72,70 @@ and `Makefile:39` all agree on this.
 cache, QEMU arm64). The `helm-publish` job additionally polls `charts.support.tools` for up to
 5 minutes waiting for the chart to appear.
 
-### The four release jobs in detail
+### The release jobs in detail
 
 | Job | Needs | What it does |
 |---|---|---|
-| `docker` | — | Multi-arch (`linux/amd64,linux/arm64`) build of `Dockerfile`, pushed to `docker.io/supporttools/node-doctor`. Tags from `docker/metadata-action`: `{{version}}`, `{{major}}.{{minor}}`, and `latest` (the last suppressed for `rc`/`beta`/`alpha` tags). Then signs **one** tag with keyless cosign. |
+| `docker` | — | Resolves the release version once — `github.ref_name` with the `v` stripped, pinned to a safe charset and exported as a job output, so no other job re-derives it from the raw ref. Multi-arch (`linux/amd64,linux/arm64`) build of `Dockerfile`, pushed to `docker.io/supporttools/node-doctor`. Tags from `docker/metadata-action`: `{{version}}`, `{{major}}.{{minor}}`, and `latest` (the last suppressed for `rc`/`beta`/`alpha` tags). Then signs **one** tag with keyless cosign. |
 | `docker-overlay-test` | — | Same, for `Dockerfile.overlay-test` -> `docker.io/supporttools/node-doctor-overlay-test`. **No cosign signing at all.** |
+| `grype-scan` | `docker` | Scans the published image with `anchore/scan-action` and uploads SARIF to GitHub Security. Informational: `fail-build: false`, never gates a release. Lives here rather than in `ci.yml` because it needs a *published* image. |
 | `github-release` | `docker`, `docker-overlay-test` | Creates the GitHub Release from a heredoc template. Attaches exactly two files: `deployment/rbac.yaml` and `deployment/daemonset.yaml`. Marked prerelease for `rc`/`beta`/`alpha` tags. |
-| `helm-publish` | `docker` | Regenerates `Chart.yaml`/`values.yaml` from templates, lints, packages, commits the `.tgz` into `SupportTools/helm-chart` (using `secrets.BOT_TOKEN`), reindexes, then polls `https://charts.support.tools/` until the version appears (30 tries x 10s). |
-| `release-complete` | all of the above | `if: always()`; re-checks each result and fails the run if any job did not succeed. |
+| `helm-publish` | `docker`, `docker-overlay-test` | Regenerates `Chart.yaml`/`values.yaml` from templates, lints, packages, **verifies every image the packaged chart references actually exists in the registry**, then commits the `.tgz` into `SupportTools/helm-chart` (using `secrets.BOT_TOKEN`), reindexes, and polls `https://charts.support.tools/` until the version appears (30 tries x 10s). It waits on `docker-overlay-test` so both images exist by the time that verification runs. |
+| `release-complete` | `docker`, `docker-overlay-test`, `github-release`, `helm-publish` | `if: always()`; re-checks each result and fails the run if any job did not succeed. |
+| `notify-failure` | all of the above | `if: failure()`; posts the per-job results and a run link to Slack. See [Release failure is a signal, not a colour](#release-failure-is-a-signal-not-a-colour). |
+
+### Release failure is a signal, not a colour
+
+A red release run is not, by itself, something anyone receives.
+
+`helm-publish`'s `Verify Chart Availability` step polls `charts.support.tools` and hard-fails
+when the chart never appears. It did exactly that, correctly, on every tag from `v1.8.0` to
+`v1.8.6` — and across eight repositories for six months nobody noticed, because nothing pushed
+the failure anywhere a human looks. The detection was never missing. The delivery was.
+
+Two things now surface it:
+
+1. **`notify-failure`** in `release.yml` — `if: failure()`, posts to Slack via the organization
+   `SLACK_WEBHOOK_URL` webhook with the per-job results and a link to the run. It states the
+   consequence explicitly ("charts.support.tools still serves the previous version") so the
+   message is actionable without opening the run.
+2. **`.github/workflows/release-audit.yml`** — a daily scheduled job (13:00 UTC, plus
+   `workflow_dispatch`) comparing the newest `v*` git tag against the chart version actually
+   served by `charts.support.tools`, with a one-hour grace period for an in-flight release.
+   This catches the whole class rather than one cause: a release run that was never started,
+   was cancelled, was re-run into a green state, or whose notification failed to deliver still
+   shows up the next morning.
+
+If you add a new failure mode to the release path, make sure it lands in one of those two.
+
+## Release credentials
+
+**`BOT_TOKEN` is the sole chart-publish credential.** It is an organization secret used at
+exactly one place — the `Checkout helm-chart repository` step of `helm-publish` — to check out
+and push to `SupportTools/helm-chart`. If charts stop publishing, this is the credential to
+check first; an expired `BOT_TOKEN` presents as `helm-publish` failing at checkout or at
+`git push`.
+
+| Secret | Used by node-doctor | Purpose |
+|---|---|---|
+| `BOT_TOKEN` | `release.yml` (`helm-publish`) | push the packaged chart to `SupportTools/helm-chart` |
+| `DOCKER_USERNAME` / `DOCKER_PASSWORD` | `release.yml`, `ci.yml` | Docker Hub push (release) and authenticated base-image pulls (CI) |
+| `SLACK_WEBHOOK_URL` | `release.yml`, `release-audit.yml` | failure notifications |
+| `CODECOV_TOKEN` | `ci.yml` | coverage upload (informational) |
+
+### `HELM_CHART_PAT` is not this repo's credential
+
+The organization secret `HELM_CHART_PAT` (created 2023-10-27, visibility: all) looks like it
+ought to be the chart-publishing credential, and it is not — **no node-doctor workflow
+references it.** Do not rotate it, do not extend its expiry, and do not investigate it when a
+node-doctor chart fails to publish. That is a dead end; the credential in play is `BOT_TOKEN`.
+
+It is *not* org-wide dead, though. An org-wide scan finds 13 repositories publishing to
+`SupportTools/helm-chart`: 12 use `BOT_TOKEN`, and `SupportTools/powerdns-admin-proxy`
+(`.github/workflows/build.yml`) still uses `HELM_CHART_PAT`. So it cannot simply be deleted —
+that repository would break. Any cleanup means migrating `powerdns-admin-proxy` to `BOT_TOKEN`
+first. Treat `HELM_CHART_PAT` as "in use by exactly one legacy consumer, out of scope for
+node-doctor".
 
 ## Which Helm chart files actually ship
 
@@ -107,10 +175,13 @@ entirely on which of those two groups it lands in.
 fails the build on any drift. `make helm-lint` depends on it, so a local lint catches this too.
 
 The three variables `envsubst` substitutes are `CHART_VERSION`, `APP_VERSION` and `IMAGE_TAG`.
-In CI they come from the tag (`CHART_VERSION` is the tag with the `v` stripped; the other two
-are the tag verbatim). Locally, `make helm-generate` substitutes fixed placeholders
-(`1.0.0` / `v1.0.0` / `v1.0.0`, see `Makefile:405-407`) purely so the committed copies are
-byte-reproducible and diffable — those placeholder values are never what ships.
+In CI they come from the tag: **`CHART_VERSION` and `IMAGE_TAG` are the tag with the `v`
+stripped; only `APP_VERSION` is the tag verbatim.** Locally, `make helm-generate` substitutes
+fixed placeholders (`1.0.0` / `v1.0.0` / `1.0.0`, see the `HELM_PLACEHOLDER_*` variables in the
+`Makefile`) purely so the committed copies are byte-reproducible and diffable — those
+placeholder values are never what ships. The placeholders mirror the same `v`-stripped/`v`-kept
+asymmetry as CI on purpose; see
+[Which image tags actually exist](#which-image-tags-actually-exist).
 
 ### Verifying a chart change actually shipped
 
@@ -126,36 +197,46 @@ what `kubectl get ds` reports.
 
 ## Which image tags actually exist
 
-Two different workflows push to `docker.io/supporttools/node-doctor` on the same tag push, and
-they use **different tag naming**. This matters, because the Helm chart points at the tag
-produced by the *less* reliable of the two.
+**Image tags are `v`-stripped. `appVersion` keeps the `v`. That asymmetry is deliberate.**
+
+`docker/metadata-action` publishes `type=semver,pattern={{version}}`, which strips the leading
+`v`. The image on Docker Hub is `1.9.0`. **There is no `v1.9.0`, and nothing publishes one.**
 
 | Tag on Docker Hub | Pushed by | Platforms | Signed |
 |---|---|---|---|
 | `1.9.0` (no `v`) | `release.yml` `docker` job | amd64 + arm64 | yes, keyless cosign |
 | `1.9` (no `v`) | `release.yml` `docker` job | amd64 + arm64 | no |
-| `latest` | `release.yml` (multi-arch, non-prerelease only) **and** `ci.yml` (amd64 only, any `v*` tag) | whichever job finished last | no |
-| `v1.9.0` (with `v`) | `ci.yml` `docker` job only | **amd64 only** | no |
+| `latest` | `release.yml` only, non-prerelease tags only | amd64 + arm64 | no |
+| `v1.9.0` (with `v`) | **nothing — this tag does not exist** | — | — |
 
 `helm/node-doctor/values.yaml.template` sets both `image.tag` and `overlayTest.image.tag` to
-`${IMAGE_TAG}`, and `release.yml` sets `IMAGE_TAG=${{ github.ref_name }}` — i.e. the **`v`-prefixed**
-form. Two consequences follow:
+`${IMAGE_TAG}`, and `release.yml` sets `IMAGE_TAG` to the `v`-stripped version, so the chart's
+defaults resolve to the multi-arch, cosign-signed images. `APP_VERSION` — which becomes
+`Chart.yaml` `appVersion` — keeps the `v`, because it is a human-facing release name and not a
+registry reference. **Do not "fix" one to match the other.**
 
-1. **The chart's default `image.tag` resolves to the amd64-only image.** The multi-arch image
-   published by `release.yml` lives under the un-prefixed tag, which the chart never references.
-2. **`supporttools/node-doctor-overlay-test:v<X.Y.Z>` has never existed.** `ci.yml` only builds
-   the main image, so nothing ever pushes a `v`-prefixed overlay-test tag. The chart's
-   `overlayTest.image.tag` default has always pointed at a tag that is not in the registry.
+### How this used to be broken
 
-And when `ci.yml` fails on a tag, the `v`-prefixed tag is never pushed at all. That is the state
-of `v1.8.7` today: chart `1.8.7` is published and defaults to `image.tag: "v1.8.7"`, but
-`supporttools/node-doctor:v1.8.7` does not exist on Docker Hub. A default `helm install` of that
-chart version pulls nothing.
+`IMAGE_TAG` was previously `github.ref_name`, i.e. `v1.9.0`, so every published chart defaulted
+to image tags that had never been pushed:
 
-**Until this is fixed in the chart template, always pin the image tag explicitly when installing
-or upgrading**, using the un-prefixed, multi-arch, cosign-signed tag:
+- **`supporttools/node-doctor-overlay-test:v<X.Y.Z>` has never existed for any version.**
+  `release.yml` is its only publisher and has always pushed `v`-stripped, so the chart's
+  `overlayTest.image.tag` default pointed at a tag that was not in the registry — always.
+- The main image's `v`-prefixed tag existed only when `ci.yml`'s duplicate, amd64-only `docker`
+  job happened to win a race against `release.yml`. When `ci.yml` failed on a tag, it was not
+  pushed at all. That is the state of `v1.8.7`: chart `1.8.7` defaults to `image.tag: "v1.8.7"`,
+  which does not exist on Docker Hub.
+
+Removing `ci.yml` as a publisher would have removed the last thing producing the `v`-prefixed
+main-image tag, so the two changes had to ship together.
+
+**Consequence for older releases: chart versions up to and including `1.8.7` still carry the
+broken `v`-prefixed defaults, and no fix can retroactively change an already-published chart.**
+If you install one of those versions, pin the tags explicitly:
 
 ```bash
+# Only needed for chart 1.8.7 and earlier
 helm upgrade --install node-doctor supporttools/node-doctor \
   --namespace node-doctor --create-namespace \
   --version 1.8.7 \
@@ -163,12 +244,29 @@ helm upgrade --install node-doctor supporttools/node-doctor \
   --set overlayTest.image.tag=1.8.7
 ```
 
-Verify before you install:
+From the first release cut after this change, the chart defaults are correct and no `--set` is
+required.
+
+### The guard that keeps it fixed
+
+`helm-publish` will not publish a chart whose images do not exist. After `helm package`, a
+`Verify packaged chart references images that exist` step reads `image.repository`/`image.tag`
+and `overlayTest.image.*` back out of the **packaged tarball** — not the working tree, so it
+checks exactly what ships — and runs `docker manifest inspect` on each. Any reference that does
+not resolve fails the release before anything reaches `charts.support.tools`.
+
+That guard is not specific to the `v` prefix: it catches any future drift between what the
+`docker` jobs push and what the chart defaults to.
+
+Verify by hand before you install:
 
 ```bash
 # The tag you are about to deploy must exist AND be multi-arch if you have arm64 nodes
-docker buildx imagetools inspect docker.io/supporttools/node-doctor:1.8.7
-docker buildx imagetools inspect docker.io/supporttools/node-doctor-overlay-test:1.8.7
+docker buildx imagetools inspect docker.io/supporttools/node-doctor:1.9.0
+docker buildx imagetools inspect docker.io/supporttools/node-doctor-overlay-test:1.9.0
+
+# What the published chart actually defaults to
+helm show values supporttools/node-doctor --version 1.9.0 | grep -A3 '^image:'
 ```
 
 ## Version Numbering
@@ -192,8 +290,9 @@ Examples:
 - **PATCH**: Bug fixes, backward-compatible
 - **PRERELEASE**: `-rc.N`, `-beta.N`, `-alpha.N`
 
-The Helm chart version is always the Git tag with the leading `v` removed
-(`release.yml:236-238`). Chart version and app version are never independent.
+The Helm chart version is always the Git tag with the leading `v` removed (resolved once in the
+`docker` job and passed to `helm-publish` as a job output). Chart version and app version are
+never independent.
 
 ### When to Increment
 
@@ -232,13 +331,14 @@ marked prerelease.
 - the Helm chart **is still published** to `charts.support.tools` (there is no prerelease gate
   on `helm-publish`), as chart version e.g. `1.9.0-rc.1`
 
-Two sharp edges in that substring match:
+One sharp edge remains in that substring match: it is a plain substring on the whole tag name.
+Any tag containing the letters `rc` anywhere — including in a suffix you did not intend as a
+prerelease marker — is treated as a prerelease.
 
-- `ci.yml` has no such gate. It pushes `:latest` (amd64-only) on **every** `v*` tag, including
-  prereleases. Pushing an RC tag can therefore leave `latest` pointing at RC content.
-- The match is a plain substring on the whole tag name. Any tag containing the letters `rc`
-  anywhere — including in a suffix you did not intend as a prerelease marker — is treated as a
-  prerelease.
+`ci.yml` used to defeat this exclusion entirely: it had no prerelease gate and pushed `:latest`
+(amd64-only) on **every** `v*` tag, so cutting an RC could leave `latest` pointing at RC
+content, on one architecture. `ci.yml` no longer pushes anything, so `release.yml`'s exclusion
+is now the only thing that decides `:latest`. `make bump-rc` likewise no longer tags `:latest`.
 
 ## Creating a Release
 
@@ -260,8 +360,9 @@ make helm-verify-generated
 gh run list --branch main --limit 3
 ```
 
-Step 4 is not optional. If `ci.yml` is red on the commit, `release.yml` will still publish a
-release — and the `v`-prefixed image tag the chart defaults to will be missing.
+Step 4 is not optional. `release.yml` runs no tests and does not wait for `ci.yml`, so a red
+commit still produces a complete, published release — images, GitHub Release and chart. CI being
+green on the exact commit you tag is the only gate that exists.
 
 ### Cut the tag
 
@@ -289,11 +390,11 @@ gh release view "$VER"
 gh release view "$VER" --json assets --jq '.assets[].name'
 #   expected: rbac.yaml, daemonset.yaml   (there are no binaries and no checksums.txt)
 
-# 3. Images. The un-prefixed tag is the multi-arch one.
+# 3. Images. Tags are v-stripped; both must list amd64 AND arm64.
 docker buildx imagetools inspect docker.io/supporttools/node-doctor:$CHART
 docker buildx imagetools inspect docker.io/supporttools/node-doctor-overlay-test:$CHART
 
-# 4. Cosign signature (only on the un-prefixed node-doctor tag)
+# 4. Cosign signature (only on the exact X.Y.Z node-doctor tag)
 cosign verify docker.io/supporttools/node-doctor:$CHART \
   --certificate-identity-regexp="https://github.com/supporttools/node-doctor" \
   --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
@@ -302,6 +403,11 @@ cosign verify docker.io/supporttools/node-doctor:$CHART \
 helm repo add supporttools https://charts.support.tools
 helm repo update
 helm search repo supporttools/node-doctor --version "$CHART"
+
+# 6. The published chart defaults to tags that exist (helm-publish enforces this,
+#    but confirm once after any change to the image/tag plumbing)
+helm show values supporttools/node-doctor --version "$CHART" | grep -E '^\s+tag:'
+#   expected: the v-STRIPPED version, e.g. "1.9.0" — never "v1.9.0"
 ```
 
 ## Release Checklist
@@ -325,8 +431,9 @@ helm search repo supporttools/node-doctor --version "$CHART"
 - [ ] `supporttools/node-doctor-overlay-test:<X.Y.Z>` exists and lists both amd64 and arm64
 - [ ] `cosign verify` passes on `supporttools/node-doctor:<X.Y.Z>`
 - [ ] Chart `<X.Y.Z>` visible via `helm search repo supporttools/node-doctor`
-- [ ] If `ci.yml` failed: know that `supporttools/node-doctor:v<X.Y.Z>` is missing and pin
-      `image.tag` explicitly on any install/upgrade
+- [ ] Published chart's `image.tag` / `overlayTest.image.tag` default to the **v-stripped**
+      version (`helm show values`)
+- [ ] Release run is green — and if it is not, confirm the Slack failure notification arrived
 
 ### Post-release
 
@@ -337,13 +444,13 @@ helm search repo supporttools/node-doctor --version "$CHART"
 ## Signing and Verification
 
 **What is signed:** exactly one thing — the `docker.io/supporttools/node-doctor:<X.Y.Z>` image
-tag (`v` stripped), with keyless cosign via GitHub OIDC (`release.yml:65-80`).
+tag (`v` stripped), with keyless cosign via GitHub OIDC (the `Sign Docker image` step of the
+`docker` job).
 
 **What is not signed:**
 
 - the `{{major}}.{{minor}}` tag (e.g. `1.9`)
 - the `latest` tag
-- the `v`-prefixed tag pushed by `ci.yml`
 - the `node-doctor-overlay-test` image, on any tag
 - the GitHub Release assets (`rbac.yaml`, `daemonset.yaml`)
 - the packaged Helm chart
@@ -370,8 +477,8 @@ Note this is `cosign verify` (image), not `cosign verify-blob` — there are no 
 
 ## Rollback Procedures
 
-There is **no rollback workflow.** `.github/workflows/` contains only `ci.yml`, `ci-ipv6.yml`
-and `release.yml`. Roll back with Helm.
+There is **no rollback workflow.** `.github/workflows/` contains only `ci.yml`, `ci-ipv6.yml`,
+`release.yml` and `release-audit.yml`. Roll back with Helm.
 
 ### Primary: `helm rollback`
 
@@ -488,17 +595,28 @@ explicitly what you want.
 
 ### `make helm-publish` does nothing
 
-`Makefile:443-446` packages the chart and then hits a `# CUSTOMIZE: Add your Helm chart publish
+The `helm-publish` target packages the chart and then hits a `# CUSTOMIZE: Add your Helm chart publish
 command` placeholder before printing "Helm chart published". It publishes nothing. The only path
 to `charts.support.tools` is the `helm-publish` job in `release.yml`, i.e. a tag push.
 
 ### `make bump-rc` is a direct-to-production path
 
-`Makefile:533-571` increments `.version-rc`, builds and pushes a multi-arch image, rewrites the
-image line in `deployment/daemonset.yaml` with `sed`, applies it to the `a1-ops-prd` cluster,
-then commits, tags and **pushes to `main` with `--tags`**. Pushing the tag re-triggers the full
-`release.yml`. Its console output claims it pushes "to Harbor"; it pushes to Docker Hub
-(`REGISTRY := docker.io/supporttools`). Understand all of that before running it.
+It increments `.version-rc`, builds and pushes a multi-arch image, rewrites the image line in
+`deployment/daemonset.yaml` with `sed`, applies it to the `a1-ops-prd` cluster, then commits,
+tags and **pushes to `main` with `--tags`**. Pushing the tag re-triggers the full `release.yml`.
+Understand all of that before running it.
+
+Two things about it were fixed alongside the tag-naming work, worth knowing if you remember the
+old behaviour:
+
+- It used to also tag `:latest`, so a workstation build of a *release candidate* could overwrite
+  the `:latest` that `release.yml` publishes only for stable tags. It now pushes only the RC tag.
+- Its `git commit` / `git tag` / `git push` steps used to end in `|| true`, silently swallowing
+  failures — leaving an image pushed and a cluster deployed from a revision that was never
+  tagged or pushed anywhere. They now fail loudly.
+
+Its console output used to claim it pushes "to Harbor"; it pushes to Docker Hub
+(`REGISTRY := docker.io/supporttools`), and the strings now say so.
 
 ### Useful and accurate
 
@@ -524,37 +642,61 @@ gh run view <run-id> --log --job "Publish Helm Chart"
 
 Common causes:
 
-- `secrets.BOT_TOKEN` expired or lacks write access to `SupportTools/helm-chart`
+- `secrets.BOT_TOKEN` expired or lacks write access to `SupportTools/helm-chart`. This is the
+  sole chart-publish credential — see [Release credentials](#release-credentials)
 - `git push` in the "Update Helm repository" step raced another chart publish and was rejected
 - the "Verify Chart Availability" step timed out (30 x 10s) because the static site had not
   rebuilt yet — in that case the chart *was* committed; re-check `helm repo update` before
   re-cutting a tag
 - `helm lint` failed on a `values.yaml.template` change (this is the one CI's `Helm Chart` job
   would have caught first)
+- the "Verify packaged chart references images that exist" step rejected the chart because a
+  default image tag does not resolve in the registry — see
+  [Which image tags actually exist](#which-image-tags-actually-exist). This one fails *before*
+  the chart is committed, so nothing was published and nothing needs cleaning up
 
 Note `release-complete` turns a `helm-publish` failure into a red run, but the `docker` and
-`github-release` jobs have already published by then. A failed release is a **partial** release.
+`github-release` jobs have already published by then. A failed release is a **partial** release:
+the tag, the images and the GitHub Release exist while `charts.support.tools` still serves the
+previous version. Nothing rolls that back automatically.
 
 ### `docker pull supporttools/node-doctor:v1.9.0` says not found
 
-That `v`-prefixed tag comes from `ci.yml`, not `release.yml`. If `ci.yml` failed on the tag —
-most often at the `Test` job, which skips `Build` and `Docker Build & Push` — the tag was never
-pushed. The multi-arch image still exists under the un-prefixed `1.9.0`. See
-[Which image tags actually exist](#which-image-tags-actually-exist).
+Working as intended — **no `v`-prefixed image tag exists, for any version.** Drop the `v`:
 
 ```bash
-gh run list --workflow=ci.yml --branch v1.9.0
-gh run view <run-id> --json jobs --jq '.jobs[] | "\(.conclusion)\t\(.name)"'
+docker pull supporttools/node-doctor:1.9.0
 ```
 
-### arm64 nodes stuck in `ImagePullBackOff`
+Historically `ci.yml` pushed a `v`-prefixed, amd64-only tag; it no longer publishes anything.
+See [Which image tags actually exist](#which-image-tags-actually-exist).
 
-Almost certainly the `v`-prefixed, amd64-only tag. Pin the un-prefixed tag:
+### `ImagePullBackOff` after installing the chart
+
+If you installed chart **1.8.7 or earlier**, its defaults point at `v`-prefixed tags that do not
+exist. Pin the real ones:
 
 ```bash
 helm upgrade node-doctor supporttools/node-doctor -n node-doctor \
-  --reuse-values --set image.tag=1.9.0 --set overlayTest.image.tag=1.9.0
+  --reuse-values --set image.tag=1.8.7 --set overlayTest.image.tag=1.8.7
 ```
+
+On any chart cut after the tag-naming fix this should not happen — `helm-publish` refuses to
+publish a chart whose images do not resolve. If it happens anyway on a *new* chart, the guard
+has a hole; check the `Verify packaged chart references images that exist` step in that
+release's `helm-publish` job.
+
+### arm64 nodes specifically stuck in `ImagePullBackOff`
+
+Check the manifest list actually has an arm64 entry:
+
+```bash
+docker buildx imagetools inspect docker.io/supporttools/node-doctor:1.9.0
+```
+
+Every tag `release.yml` publishes is multi-arch. A single-arch `:latest` was possible when
+`ci.yml` also pushed it (amd64-only) and won the race; `release.yml` is now the only publisher,
+so this should no longer occur.
 
 ### A chart change did not take effect
 
@@ -568,8 +710,8 @@ check `git diff` covers both files.
 ### Cosign verification fails
 
 - Use `cosign verify` (image), not `cosign verify-blob` — no blobs are signed.
-- Only the un-prefixed `<X.Y.Z>` tag on `node-doctor` is signed. `latest`, `{{major}}.{{minor}}`,
-  the `v`-prefixed tag, and the entire overlay-test image are unsigned.
+- Only the `<X.Y.Z>` tag on `node-doctor` is signed. `latest`, `{{major}}.{{minor}}` and the
+  entire overlay-test image are unsigned.
 - The workflow signs with `cosign` v2.2.2 and `COSIGN_EXPERIMENTAL=1`; the signature lives in the
   registry as a `sha256-<digest>.sig` tag.
 
@@ -591,9 +733,13 @@ Listed explicitly because previous versions of this document claimed otherwise:
 - **No Harbor.** The registry is Docker Hub throughout.
 - **No `rollback-release.yml`.** No rollback workflow of any kind exists; every
   `gh workflow run rollback-release.yml` command will fail.
-- **No changelog generation.** The release notes are a static heredoc in `release.yml:157-198`;
-  they are identical for every release apart from the version string.
+- **No changelog generation.** The release notes are a static heredoc in `release.yml`; they are
+  identical for every release apart from the version string.
 - **No tests.** `release.yml` runs none, and does not depend on `ci.yml`.
+- **No image publishing from `ci.yml`.** It once pushed to the same repository on tag events;
+  its `docker` job now builds with `push: false` and publishes nothing.
+- **No automatic backfill.** Chart versions `1.8.0`-`1.8.6` were never published and nothing
+  republishes them retroactively; the daily audit reports the gap, it does not close it.
 
 ## Support
 

--- a/helm/node-doctor/values.yaml
+++ b/helm/node-doctor/values.yaml
@@ -31,7 +31,7 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion
   # This is dynamically set by CI/CD
-  tag: "v1.0.0"
+  tag: "1.0.0"
 
 # Secrets for pulling images from private registries
 imagePullSecrets: []
@@ -497,7 +497,7 @@ overlayTest:
   # Image for overlay test pods (Go HTTP health server, scratch-based ~6MB)
   image:
     repository: supporttools/node-doctor-overlay-test
-    tag: "v1.0.0"
+    tag: "1.0.0"
     pullPolicy: IfNotPresent
 
   # HTTP health probe port


### PR DESCRIPTION
Fixes three coupled release-pipeline bugs. They ship together because they are causally linked, not merely adjacent — see 257 below. CI/workflow/chart only; no Go runtime changes.

> ⚠️ **257 blocks the v1.9.0 release.** Without it, the 255 change alone would make the chart's default image tags break for the main image too.

---

## Rebased onto `afdfc17` (five PRs landed underneath)

Two files conflicted.

**`docs/release-process.md` — the semantic one.** PR #36 rewrote this file wholesale from ground truth, describing the pipeline **as it was before this branch**. Resolved by taking main's rewrite as the base and re-applying this branch's changes on top, in a separate commit so the diff is reviewable. Neither side was taken wholesale.

The delicate part: #36 documented the broken `v`-prefixed convention as *current reality*, and built a whole section, the install guidance, a checklist item and three troubleshooting entries around it. All of those now describe the corrected convention — while **keeping the old behaviour as history**, because chart `1.8.7` and earlier still carry the broken defaults and no fix reaches an already-published chart. The pin-the-tag workaround is retained but scoped to those versions instead of standing advice.

Also updated `.github/workflows/README.md`. It was **not** a git conflict, so it would have been easy to miss — but #36 filled it with the same now-obsolete claims (ci.yml pushing `v`-prefixed amd64-only images, both workflows racing for `:latest`, the chart defaulting to the ci.yml tag) and it cross-links the very section being corrected. Leaving it would have left the repo contradicting itself one directory away.

Preserved intact from #36, as they remain true: "Which Helm chart files actually ship", `deployment/daemonset.yaml` pinning an old image the pipeline does not bump, a failed release being a partial release, and the orphaned `.goreleaser.yml` / GPG scripts.

**`helm/node-doctor/values.yaml` — mechanical.** Regenerated with `make helm-generate` rather than hand-merged, so PR #34's `cpu: 500m` and `maxUnavailable: "25%"` survive alongside this branch's `v`-stripped placeholder. `make helm-verify-generated` passes.

---

## 255 — `ci.yml` and `release.yml` raced to push the same image tag

Both workflows were gated on the same `v*` tag event and both pushed `docker.io/supporttools/node-doctor`, with **no `needs:` ordering between them**:

- `ci.yml` `docker`: `linux/amd64` only, pushed `${TAG}` **and unconditionally `latest`**.
- `release.yml` `docker`: `linux/amd64,linux/arm64`, pushes `latest` only when the ref has no `rc`/`beta`/`alpha`.

Consequences:

1. **Whichever finished last won `:latest`.** When `ci.yml` won, `:latest` became amd64-only. This fleet has arm64 nodes (`a1pinode01`/`02`) — an `exec format error` waiting to happen.
2. **An `-rc`/`-beta` tag moved `:latest` anyway** via `ci.yml`, defeating `release.yml`'s deliberate exclusion.
3. Genuine race, not theoretical.

### Fix: `release.yml` is the sole image publisher

**Why `release.yml` and not `ci.yml`:** it already builds multi-arch (amd64 + arm64 — mandatory for this fleet), cosign-signs the image, gates `latest` correctly on prerelease-ness, and publishes the chart and GitHub release from the same tag. `ci.yml`'s copy was a strictly weaker duplicate: single-arch, unsigned, no prerelease guard. Deleting the weaker publisher required no behaviour change to the surviving path.

`ci.yml`'s `docker` job loses its tag gate and builds with `push: false`. Net effect: it now validates the Dockerfile on **every PR and branch push** — earlier than before, when it only built on tags — and can never race for a tag. The Grype scan needs a *published* image, so it moved to `release.yml` (`needs: docker`), unchanged and still informational.

### `Makefile` `bump-rc`

- No longer tags `:latest`. A workstation build of a *release candidate* could overwrite the `:latest` that `release.yml` publishes only for stable tags.
- `git commit` / `git tag` / `git push` no longer end in `|| true`, which was swallowing failures and could leave an image pushed and a cluster deployed from a revision that was never tagged or pushed anywhere.
- Fixed two stale strings claiming it pushes to Harbor; `REGISTRY` is `docker.io/supporttools`.

---

## 257 — published chart defaulted to image tags that do not exist

`release.yml`'s `Prepare Helm chart files` set `IMAGE_TAG` from `github.ref_name` — **with the `v`** — and `values.yaml.template` feeds `${IMAGE_TAG}` into *both* `image.tag` and `overlayTest.image.tag`. But `docker/metadata-action` in the same workflow publishes `type=semver,pattern={{version}}`, which is **v-stripped**:

```
supporttools/node-doctor:1.8.7                200
supporttools/node-doctor:v1.8.7               404
supporttools/node-doctor-overlay-test:1.8.7   200
supporttools/node-doctor-overlay-test:v1.8.7  404
```

`helm install supporttools/node-doctor` with **default values** gives `ImagePullBackOff` on both DaemonSets. a1-ops-prd only escapes it because it is deployed with an explicit `--set image.tag=1.8.7`.

**Systemic, not a one-off.** `node-doctor-overlay-test` has never had a v-prefixed tag for *any* version — `release.yml` is its only publisher and has always pushed v-stripped, so every chart ever published defaulted to an overlay-test image that does not exist. The *main* image's v-prefixed tag existed only when `ci.yml`'s duplicate `docker` job happened to win the 255 race. **Once `release.yml` becomes the sole publisher, that tag stops being produced at all — so 255 without 257 would break the main image's chart default too.** That is why these ship in one PR.

### Fix

`IMAGE_TAG` is now v-stripped. `APP_VERSION` deliberately keeps the `v` — it is `Chart.yaml` `appVersion`, a human-facing release name, not a registry reference. Both sites carry a comment saying so, so nobody "fixes" it back for consistency. `HELM_PLACEHOLDER_IMAGE_TAG` in the `Makefile` mirrors the same asymmetry (`v1.0.0` → `1.0.0`) so the committed `values.yaml` stays an accurate model of the shipped chart; regenerated with `make helm-generate`, and `make helm-verify-generated` keeps them in sync.

### Regression guard

New `Verify packaged chart references images that exist` step in `helm-publish`. It reads the image references out of the **packaged tarball** — not the working tree, so it validates exactly what ships — and `docker manifest inspect`s each one, failing the release before anything reaches charts.support.tools. This catches the **whole class**: any future drift between what the `docker` jobs push and what the chart defaults to, not just the `v` prefix. `helm-publish` now also `needs: docker-overlay-test`, so both images exist by the time the assertion runs.

**Verified**, not assumed: the step was extracted from `release.yml` and executed against a really-packaged chart with a stubbed registry — passes on v-stripped tags, fails with the intended error on v-prefixed ones.

> **Separate latent issue, deliberately not touched:** `controller.image.tag` defaults to `""`, which falls back to `.Chart.AppVersion` (v-prefixed). No workflow publishes `supporttools/node-doctor-controller` at all, and `controller.enabled` is `false` by default, so the guard does not assert it — asserting an image nothing publishes would fail every release. Worth its own ticket.

---

## 256 — release failures were invisible

The real failure behind the six-month outage was not an expired token. `release.yml` **already had** a `Verify Chart Availability` step that polls and hard-fails, so every broken release went red *on purpose*, across 8 repos, for six months — and nobody saw it. The missing piece was never detection. It was delivery.

### ITEM 1 — `if: failure()` notification (implemented)

**An existing org mechanism was found and reused — nothing is left TODO.** Org secret `SLACK_WEBHOOK_URL` exists (visibility `all`, confirmed visible to this repo), and the established pattern is `slackapi/slack-github-action@v1.26.0` with `SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK`, as used by `SupportTools/support-decoder` `cd.yml`, `SupportTools/memory-bank` `cd.yaml` and `SupportTools/website` `cloudflare-workers-notifications.yml`. The new `notify-failure` job matches it exactly.

It posts per-job results and a run link, and names the specific consequence — "charts.support.tools still serves the previous version" — so the message is actionable without opening the run. It also writes a failure table to the run summary.

### ITEM 1(b) — scheduled audit (implemented)

New `.github/workflows/release-audit.yml`: daily at 13:00 UTC plus `workflow_dispatch`, comparing the newest `v*` git tag against the chart version actually served by charts.support.tools, with a one-hour grace period for an in-flight release. This catches the **whole class** — a release run never started, cancelled, or whose notification failed to deliver still surfaces the next morning. Failure notifies via the same Slack mechanism.

Scoped to node-doctor, using the default `GITHUB_TOKEN` and the public chart index — no new credentials. Extending it across the other SupportTools chart-publishing repos needs an owner decision on where it lives and which credential enumerates them.

### ITEM 4 — `HELM_CHART_PAT` hygiene (documented; nothing deleted)

`HELM_CHART_PAT` is *not* referenced by zero workflows org-wide. `gh api search/code` found it still in use by **`SupportTools/powerdns-admin-proxy` `.github/workflows/build.yml`**, where it checks out `SupportTools/helm-chart`. Deleting it would break that repo. (A subsequent full org scan confirmed this: 13 repos publish to `helm-chart` — 12 on `BOT_TOKEN`, plus `powerdns-admin-proxy` on `HELM_CHART_PAT`.) Nothing was deleted, and `docs/release-process.md` documents it accurately rather than as "unused / pending removal", so the next investigation is not misled in *either* direction:

- `BOT_TOKEN` is the sole chart-publish credential for node-doctor (one usage: `helm-publish` → checkout of `SupportTools/helm-chart`). An expired `BOT_TOKEN` presents as `helm-publish` failing at checkout or `git push`.
- `HELM_CHART_PAT` is a dead end **for this repo** — don't rotate it, don't investigate it when a node-doctor chart fails to publish — but it has exactly one live legacy consumer, so any cleanup means migrating `powerdns-admin-proxy` to `BOT_TOKEN` first.

### Remaining — owner decisions, NOT implemented

- **ITEM 2 — `BOT_TOKEN` expiry tracking.** No automated expiry warning exists. Needs a decision on mechanism (scheduled token-introspection job vs. calendar reminder vs. moving to a GitHub App installation token that does not expire).
- **ITEM 3 — backfill.** Whether to retroactively publish the charts missed during the six-month window, or let them stay missing and move forward from the next tag.

---

## Security

Per the constraint on workflow edits, no untrusted input is interpolated into `run:` blocks. A git tag name may legally contain `$`, backticks, quotes and `;`, and `github.ref_name` was being interpolated straight into shell in the cosign-sign, chart-version and summary steps — a real command-injection vector for anyone who can push a tag. It is now passed via `env:`, quoted, and pinned to a known-safe charset once in the `docker` job (hard-failing the release on anything unexpected), then carried downstream as a job output. Same treatment in the new notification and audit jobs before the value reaches a JSON payload.

## Preserved

The `Helm Chart` CI job (`make helm-verify-generated` + `helm lint`) is untouched and still in `ci-success`'s `needs:`. The new `docker` validation job is gated the same way — through `ci-success` rather than as a new required status check — so already-open PRs are not left stuck on "Expected — waiting for status".

## Validation

- `make build`, `make test` — pass
- `make helm-verify-generated`, `helm lint ./helm/node-doctor` — pass after regeneration
- `python3 yaml.safe_load` on all 4 workflows — parse clean
- `actionlint` — **clean, exit 0** (also fixed the one pre-existing `SC2219` it flagged)
- `make -n bump-rc` — `:latest` gone from the buildx invocation, git steps no longer `|| true`
- New chart-image guard — executed against a real packaged tarball, both pass and fail paths
- Doc cross-references — all intra-document anchors validated by script, 0 broken; every `file:line` reference in the doc re-checked against the current files (three still correct, two corrected)
- **Post-rebase CI — all 8 jobs green** (Lint, Test, Build, gosec, Helm Chart, Pinger ICMP, Docker Build (no push), CI Success). PR is `MERGEABLE` / `CLEAN`.

## Not done, deliberately

Not merged, not tagged, no secret deleted, no cluster touched.

Task: #node-doctor-255
Task: #node-doctor-256
Task: #node-doctor-257

https://claude.ai/code/session_01Av4whriQf6KqJgRxGKQP7N
