### PR TITLE
fix(peers): make the discovered peer set authoritative, prune stale peers

### DIFF
--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -89,6 +89,8 @@ These dashboards require the following Prometheus metrics exported by Node Docto
 | `node_doctor_monitor_peer_reachable` | Gauge | node, peer_node, peer_ip | Peer reachability (1=reachable, 0=unreachable) |
 | `node_doctor_monitor_peers_total` | Gauge | node | Total number of discovered peers |
 | `node_doctor_monitor_peers_reachable_total` | Gauge | node | Number of reachable peers |
+| `node_doctor_monitor_peer_set_size` | Gauge | node | Size of the current authoritative discovered peer set. Should equal (nodes - 1) on every node regardless of agent uptime; a node reporting more than its neighbours is holding stale peers |
+| `node_doctor_monitor_peer_set_churn_total` | Counter | node, change | Peer identities entering (`change="added"`) or leaving (`change="removed"`) the exported peer set. A rename or re-address is one removal plus one addition |
 | `node_doctor_monitor_peer_latency_histogram_seconds` | Histogram | node | Histogram of peer latency for percentile calculations |
 | `node_doctor_monitor_gateway_latency_seconds` | Gauge | node | Latency to default gateway |
 | `node_doctor_monitor_gateway_latency_histogram_seconds` | Histogram | node | Histogram of gateway latency |

--- a/pkg/exporters/prometheus/exporter.go
+++ b/pkg/exporters/prometheus/exporter.go
@@ -41,6 +41,11 @@ type PrometheusExporter struct {
 	// TOCTOU race.
 	ephemeral bool
 
+	// lastPeerSeries is the set of peer identities published on the most recent
+	// peer-carrying status. It is the baseline for deleting stale peer gauge
+	// series and for computing peer-set churn. Guarded by mu.
+	lastPeerSeries map[peerSeriesKey]struct{}
+
 	// consecutiveFailures tracks the running count of failed exports since the
 	// last successful export. It backs the ExporterConsecutiveFailures gauge and
 	// is guarded by mu to avoid racy read-modify-write on the gauge itself.
@@ -408,6 +413,97 @@ func (e *PrometheusExporter) ObserveCircuitState(state int) {
 	e.metrics.RemediatorCircuitBreakerState.WithLabelValues(e.nodeName).Set(float64(state))
 }
 
+// peerSeriesKey identifies one exported peer identity: the label tuple that a
+// peer gauge series is keyed by (excluding the constant "node" label of the
+// exporting agent). A rename or re-address produces a DIFFERENT key, which is
+// exactly what makes the pre-rename identity detectable as stale.
+type peerSeriesKey struct {
+	node   string
+	ip     string
+	family string
+}
+
+// reconcilePeerSeries makes the peer set published by this cycle authoritative for
+// the Prometheus registry and records peer-set churn.
+//
+// Prometheus *Vec collectors keep every label combination they have ever been
+// handed until the series is explicitly deleted or the process restarts. Without
+// this reconciliation, a peer that was renamed or re-addressed left its old
+// (peer_node, peer_ip, address_family) series behind at its last written value
+// forever. Those frozen series are indistinguishable from live ones to PromQL, so
+//
+//	avg by (node, address_family) (node_doctor_monitor_peer_reachable)
+//
+// stayed pinned below 100% (e.g. exactly 75% with one dead target out of four) and
+//
+//	max by (node) (node_doctor_monitor_peer_latency_seconds)
+//
+// reported the dead target's last, worst latency. Both correlated perfectly with
+// agent uptime and cleared only on restart.
+//
+// Called only with a non-empty current set, so a status that carries no peers (a
+// discovery blip, or a different monitor's latency status) never deletes series.
+func (e *PrometheusExporter) reconcilePeerSeries(current map[peerSeriesKey]struct{}) {
+	e.mu.Lock()
+	previous := e.lastPeerSeries
+	e.lastPeerSeries = current
+	e.mu.Unlock()
+
+	var added, removed int
+
+	for key := range current {
+		if _, ok := previous[key]; !ok {
+			added++
+		}
+	}
+
+	for key := range previous {
+		if _, ok := current[key]; ok {
+			continue
+		}
+		removed++
+
+		labels := prometheus.Labels{
+			"node":           e.nodeName,
+			"peer_node":      key.node,
+			"peer_ip":        key.ip,
+			"address_family": key.family,
+		}
+		e.metrics.PeerLatencySeconds.Delete(labels)
+		e.metrics.PeerLatencyAvgSeconds.Delete(labels)
+		e.metrics.PeerReachable.Delete(labels)
+	}
+
+	// The latency histogram is keyed only by peer_node, so it is dropped only when
+	// the peer name itself is gone (a re-address keeps the same histogram series).
+	for key := range previous {
+		if _, ok := current[key]; ok {
+			continue
+		}
+		stillPresent := false
+		for cur := range current {
+			if cur.node == key.node {
+				stillPresent = true
+				break
+			}
+		}
+		if !stillPresent {
+			e.metrics.PeerLatencyHistogram.DeleteLabelValues(e.nodeName, key.node)
+		}
+	}
+
+	if added > 0 {
+		e.metrics.PeerSetChurnTotal.WithLabelValues(e.nodeName, "added").Add(float64(added))
+	}
+	if removed > 0 {
+		e.metrics.PeerSetChurnTotal.WithLabelValues(e.nodeName, "removed").Add(float64(removed))
+	}
+	// Touch both series so they exist at 0 from the first publication and PromQL
+	// rate()/increase() over them is well defined.
+	e.metrics.PeerSetChurnTotal.WithLabelValues(e.nodeName, "added")
+	e.metrics.PeerSetChurnTotal.WithLabelValues(e.nodeName, "removed")
+}
+
 // recordLatencyMetrics extracts latency metrics from status metadata and records them
 func (e *PrometheusExporter) recordLatencyMetrics(status *types.Status) {
 	latencyMetrics := status.GetLatencyMetrics()
@@ -430,11 +526,14 @@ func (e *PrometheusExporter) recordLatencyMetrics(status *types.Status) {
 	// Record peer latency metrics
 	if len(latencyMetrics.Peers) > 0 {
 		reachableCount := 0
+		current := make(map[peerSeriesKey]struct{}, len(latencyMetrics.Peers))
+
 		for _, peer := range latencyMetrics.Peers {
 			latencySeconds := peer.LatencyMs / 1000.0
 			avgLatencySeconds := peer.AvgLatencyMs / 1000.0
 
 			family := familyLabel(peer.AddressFamily)
+			current[peerSeriesKey{node: peer.PeerNode, ip: peer.PeerIP, family: family}] = struct{}{}
 
 			e.metrics.PeerLatencySeconds.WithLabelValues(
 				e.nodeName, peer.PeerNode, peer.PeerIP, family).Set(latencySeconds)
@@ -454,8 +553,11 @@ func (e *PrometheusExporter) recordLatencyMetrics(status *types.Status) {
 				e.nodeName, peer.PeerNode).Observe(latencySeconds)
 		}
 
+		e.reconcilePeerSeries(current)
+
 		e.metrics.PeersTotal.WithLabelValues(e.nodeName).Set(float64(len(latencyMetrics.Peers)))
 		e.metrics.PeersReachableTotal.WithLabelValues(e.nodeName).Set(float64(reachableCount))
+		e.metrics.PeerSetSize.WithLabelValues(e.nodeName).Set(float64(len(current)))
 	}
 
 	// Record DNS latency metrics

--- a/pkg/exporters/prometheus/metrics.go
+++ b/pkg/exporters/prometheus/metrics.go
@@ -58,6 +58,8 @@ type Metrics struct {
 	PeerReachable                 *prometheus.GaugeVec
 	PeersTotal                    *prometheus.GaugeVec
 	PeersReachableTotal           *prometheus.GaugeVec
+	PeerSetSize                   *prometheus.GaugeVec
+	PeerSetChurnTotal             *prometheus.CounterVec
 	DNSLatencySeconds             *prometheus.GaugeVec
 	DNSNameserverHealthScore      *prometheus.GaugeVec
 	DNSNameserverSuccessScore     *prometheus.GaugeVec
@@ -397,6 +399,28 @@ func NewMetrics(namespace, subsystem string, constLabels prometheus.Labels) (*Me
 			[]string{"node"},
 		),
 
+		PeerSetSize: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace:   namespace,
+				Subsystem:   subsystem,
+				Name:        "peer_set_size",
+				Help:        "Number of peers in the current authoritative discovered peer set. Should equal (cluster nodes - 1) on every node regardless of agent uptime; a node reporting more than its neighbours is holding stale peers.",
+				ConstLabels: labels,
+			},
+			[]string{"node"},
+		),
+
+		PeerSetChurnTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace:   namespace,
+				Subsystem:   subsystem,
+				Name:        "peer_set_churn_total",
+				Help:        "Cumulative count of peer identities entering (change=added) or leaving (change=removed) the exported peer set. A peer identity is the (peer_node, peer_ip, address_family) tuple, so a rename or re-address counts as one removal plus one addition.",
+				ConstLabels: labels,
+			},
+			[]string{"node", "change"},
+		),
+
 		DNSLatencySeconds: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   namespace,
@@ -625,6 +649,8 @@ func (m *Metrics) Register(registry *prometheus.Registry) error {
 		m.PeerReachable,
 		m.PeersTotal,
 		m.PeersReachableTotal,
+		m.PeerSetSize,
+		m.PeerSetChurnTotal,
 		m.DNSLatencySeconds,
 		m.DNSNameserverHealthScore,
 		m.DNSNameserverSuccessScore,
@@ -683,6 +709,8 @@ func (m *Metrics) Unregister(registry *prometheus.Registry) {
 		m.PeerReachable,
 		m.PeersTotal,
 		m.PeersReachableTotal,
+		m.PeerSetSize,
+		m.PeerSetChurnTotal,
 		m.DNSLatencySeconds,
 		m.DNSNameserverHealthScore,
 		m.DNSNameserverSuccessScore,

--- a/pkg/exporters/prometheus/peer_series_prune_test.go
+++ b/pkg/exporters/prometheus/peer_series_prune_test.go
@@ -1,0 +1,317 @@
+package prometheus
+
+import (
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/supporttools/node-doctor/pkg/types"
+)
+
+// peerStatus builds a status carrying the given peer set as latency metrics, the
+// same shape the CNI monitor publishes each check cycle.
+func peerStatus(peers ...types.PeerLatency) *types.Status {
+	s := types.NewStatus("network-cni-check")
+	s.SetLatencyMetrics(&types.LatencyMetrics{Peers: peers})
+	return s
+}
+
+func peer(node, ip string, reachable bool, latencyMs float64) types.PeerLatency {
+	return types.PeerLatency{
+		PeerNode:      node,
+		PeerIP:        ip,
+		LatencyMs:     latencyMs,
+		AvgLatencyMs:  latencyMs,
+		Reachable:     reachable,
+		AddressFamily: "ipv4",
+	}
+}
+
+// peerSeriesLabels returns the (peer_node, peer_ip) pairs currently exported for
+// the named metric family.
+func peerSeriesLabels(t *testing.T, families []*dto.MetricFamily, metricName string) map[[2]string]float64 {
+	t.Helper()
+	out := map[[2]string]float64{}
+	for _, mf := range families {
+		if mf.GetName() != metricName {
+			continue
+		}
+		for _, m := range mf.Metric {
+			var node, ip string
+			for _, l := range m.Label {
+				switch l.GetName() {
+				case "peer_node":
+					node = l.GetValue()
+				case "peer_ip":
+					ip = l.GetValue()
+				}
+			}
+			var v float64
+			switch {
+			case m.Gauge != nil:
+				v = m.Gauge.GetValue()
+			case m.Counter != nil:
+				v = m.Counter.GetValue()
+			case m.Histogram != nil:
+				v = float64(m.Histogram.GetSampleCount())
+			}
+			out[[2]string{node, ip}] = v
+		}
+	}
+	return out
+}
+
+func gaugeValueWithLabels(t *testing.T, families []*dto.MetricFamily, metricName string, want map[string]string) (float64, bool) {
+	t.Helper()
+	for _, mf := range families {
+		if mf.GetName() != metricName {
+			continue
+		}
+	metric:
+		for _, m := range mf.Metric {
+			have := map[string]string{}
+			for _, l := range m.Label {
+				have[l.GetName()] = l.GetValue()
+			}
+			for k, v := range want {
+				if have[k] != v {
+					continue metric
+				}
+			}
+			switch {
+			case m.Gauge != nil:
+				return m.Gauge.GetValue(), true
+			case m.Counter != nil:
+				return m.Counter.GetValue(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+// TestPeerSeriesPrunedWhenPeerLeavesDiscovery is the regression test for
+// node-doctor-251. Prometheus *Vec collectors retain every label combination they
+// have ever seen, so a peer that vanished from discovery used to keep exporting
+// its last written peer_reachable=0 forever. With three live peers plus one dead
+// identity, avg(peer_reachable) reads exactly 75% on an agent that has been up
+// long enough to have seen the dead peer -- the uniform-75%-across-many-nodes
+// signature from the incident -- while a freshly restarted agent reads 100%.
+func TestPeerSeriesPrunedWhenPeerLeavesDiscovery(t *testing.T) {
+	e, err := newEphemeralExporter(&types.GlobalSettings{NodeName: "test-node"})
+	if err != nil {
+		t.Fatalf("newEphemeralExporter: %v", err)
+	}
+
+	// Cycle 1: four peers, one of them already failing (the node is being retired).
+	e.recordLatencyMetrics(peerStatus(
+		peer("node-a", "10.0.0.1", true, 1),
+		peer("node-b", "10.0.0.2", true, 1),
+		peer("node-c", "10.0.0.3", true, 1),
+		peer("node-dead", "10.0.0.4", false, 500),
+	))
+
+	// Cycle 2: the retired node is gone from discovery.
+	e.recordLatencyMetrics(peerStatus(
+		peer("node-a", "10.0.0.1", true, 1),
+		peer("node-b", "10.0.0.2", true, 1),
+		peer("node-c", "10.0.0.3", true, 1),
+	))
+
+	families, err := e.registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+
+	reachable := peerSeriesLabels(t, families, "test_peer_reachable")
+	if len(reachable) != 3 {
+		t.Errorf("peer_reachable has %d series, want 3: %v", len(reachable), reachable)
+	}
+	if _, stale := reachable[[2]string{"node-dead", "10.0.0.4"}]; stale {
+		t.Error("peer_reachable still exports the removed peer node-dead/10.0.0.4")
+	}
+
+	// avg(peer_reachable) -- what NodeDoctorLowPeerConnectivity evaluates -- must be
+	// 100%, not the 75% a stale fourth series produces.
+	var sum float64
+	for _, v := range reachable {
+		sum += v
+	}
+	if got := sum / float64(len(reachable)); got != 1.0 {
+		t.Errorf("avg(peer_reachable) = %v, want 1.0 (a stale dead peer pins this at 0.75)", got)
+	}
+
+	// max(peer_latency_seconds) -- what NodeDoctorHighPeerLatency evaluates -- must
+	// not be dominated by the dead peer's frozen 500ms timeout reading.
+	latency := peerSeriesLabels(t, families, "test_peer_latency_seconds")
+	if _, stale := latency[[2]string{"node-dead", "10.0.0.4"}]; stale {
+		t.Error("peer_latency_seconds still exports the removed peer's frozen timeout latency")
+	}
+	for k, v := range latency {
+		if v > 0.1 {
+			t.Errorf("peer_latency_seconds%v = %v, want no series above 100ms", k, v)
+		}
+	}
+
+	if _, stale := peerSeriesLabels(t, families, "test_peer_latency_avg_seconds")[[2]string{"node-dead", "10.0.0.4"}]; stale {
+		t.Error("peer_latency_avg_seconds still exports the removed peer")
+	}
+}
+
+// TestPeerSeriesPrunedOnRenameAndReAddress covers the exact identities seen in the
+// incident: a node renamed (a1pidnsp02 -> a1pinode01) and re-addressed
+// (172.28.1.41 -> 172.28.1.14). Neither the old name nor the old IP may survive.
+func TestPeerSeriesPrunedOnRenameAndReAddress(t *testing.T) {
+	e, err := newEphemeralExporter(&types.GlobalSettings{NodeName: "test-node"})
+	if err != nil {
+		t.Fatalf("newEphemeralExporter: %v", err)
+	}
+
+	e.recordLatencyMetrics(peerStatus(
+		peer("a1pidnsp02", "172.28.1.41", true, 2),
+		peer("a1pinode02", "172.28.1.15", true, 2),
+	))
+	e.recordLatencyMetrics(peerStatus(
+		peer("a1pinode01", "172.28.1.14", true, 2),
+		peer("a1pinode02", "172.28.1.15", true, 2),
+	))
+
+	families, err := e.registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+
+	for _, metric := range []string{"test_peer_reachable", "test_peer_latency_seconds", "test_peer_latency_avg_seconds"} {
+		series := peerSeriesLabels(t, families, metric)
+		if len(series) != 2 {
+			t.Errorf("%s has %d series, want 2: %v", metric, len(series), series)
+		}
+		if _, stale := series[[2]string{"a1pidnsp02", "172.28.1.41"}]; stale {
+			t.Errorf("%s still exports the pre-rename identity a1pidnsp02/172.28.1.41", metric)
+		}
+		if _, ok := series[[2]string{"a1pinode01", "172.28.1.14"}]; !ok {
+			t.Errorf("%s missing the current identity a1pinode01/172.28.1.14", metric)
+		}
+	}
+
+	// The latency histogram is keyed by peer_node only; the vanished name must go.
+	hist := peerSeriesLabels(t, families, "test_peer_latency_histogram_seconds")
+	if _, stale := hist[[2]string{"a1pidnsp02", ""}]; stale {
+		t.Error("peer_latency_histogram_seconds still exports the pre-rename peer_node")
+	}
+}
+
+// TestPeerSetSizeAndChurnMetrics verifies the peer-set size gauge and churn counter
+// track reality, so a stale-peer regression is visible instead of silent.
+func TestPeerSetSizeAndChurnMetrics(t *testing.T) {
+	e, err := newEphemeralExporter(&types.GlobalSettings{NodeName: "test-node"})
+	if err != nil {
+		t.Fatalf("newEphemeralExporter: %v", err)
+	}
+
+	nodeLabels := map[string]string{"node": "test-node"}
+	addedLabels := map[string]string{"node": "test-node", "change": "added"}
+	removedLabels := map[string]string{"node": "test-node", "change": "removed"}
+
+	gather := func() []*dto.MetricFamily {
+		t.Helper()
+		families, err := e.registry.Gather()
+		if err != nil {
+			t.Fatalf("Gather: %v", err)
+		}
+		return families
+	}
+
+	// Cycle 1: three peers discovered for the first time.
+	e.recordLatencyMetrics(peerStatus(
+		peer("node-a", "10.0.0.1", true, 1),
+		peer("node-b", "10.0.0.2", true, 1),
+		peer("node-c", "10.0.0.3", true, 1),
+	))
+	families := gather()
+	if got, ok := gaugeValueWithLabels(t, families, "test_peer_set_size", nodeLabels); !ok || got != 3 {
+		t.Errorf("peer_set_size = %v (found=%v), want 3", got, ok)
+	}
+	if got, ok := gaugeValueWithLabels(t, families, "test_peer_set_churn_total", addedLabels); !ok || got != 3 {
+		t.Errorf("peer_set_churn_total{change=added} = %v (found=%v), want 3", got, ok)
+	}
+	if got, ok := gaugeValueWithLabels(t, families, "test_peer_set_churn_total", removedLabels); !ok || got != 0 {
+		t.Errorf("peer_set_churn_total{change=removed} = %v (found=%v), want 0", got, ok)
+	}
+
+	// Cycle 2: identical set -> no churn.
+	e.recordLatencyMetrics(peerStatus(
+		peer("node-a", "10.0.0.1", true, 1),
+		peer("node-b", "10.0.0.2", true, 1),
+		peer("node-c", "10.0.0.3", true, 1),
+	))
+	families = gather()
+	if got, _ := gaugeValueWithLabels(t, families, "test_peer_set_churn_total", addedLabels); got != 3 {
+		t.Errorf("added churn after a no-change cycle = %v, want 3", got)
+	}
+	if got, _ := gaugeValueWithLabels(t, families, "test_peer_set_churn_total", removedLabels); got != 0 {
+		t.Errorf("removed churn after a no-change cycle = %v, want 0", got)
+	}
+
+	// Cycle 3: node-c is re-addressed -> one identity out, one in; size unchanged.
+	e.recordLatencyMetrics(peerStatus(
+		peer("node-a", "10.0.0.1", true, 1),
+		peer("node-b", "10.0.0.2", true, 1),
+		peer("node-c", "10.0.0.99", true, 1),
+	))
+	families = gather()
+	if got, _ := gaugeValueWithLabels(t, families, "test_peer_set_size", nodeLabels); got != 3 {
+		t.Errorf("peer_set_size after re-address = %v, want 3", got)
+	}
+	if got, _ := gaugeValueWithLabels(t, families, "test_peer_set_churn_total", addedLabels); got != 4 {
+		t.Errorf("added churn after re-address = %v, want 4", got)
+	}
+	if got, _ := gaugeValueWithLabels(t, families, "test_peer_set_churn_total", removedLabels); got != 1 {
+		t.Errorf("removed churn after re-address = %v, want 1", got)
+	}
+
+	// Cycle 4: one peer leaves for good.
+	e.recordLatencyMetrics(peerStatus(
+		peer("node-a", "10.0.0.1", true, 1),
+		peer("node-b", "10.0.0.2", true, 1),
+	))
+	families = gather()
+	if got, _ := gaugeValueWithLabels(t, families, "test_peer_set_size", nodeLabels); got != 2 {
+		t.Errorf("peer_set_size after removal = %v, want 2", got)
+	}
+	if got, _ := gaugeValueWithLabels(t, families, "test_peer_set_churn_total", removedLabels); got != 2 {
+		t.Errorf("removed churn after removal = %v, want 2", got)
+	}
+}
+
+// TestPeerlessStatusDoesNotWipePeerSeries is the fail-safe guard: a status that
+// carries no peers (a monitor publishing only gateway/DNS latency, or a CNI cycle
+// that found no peers at all because discovery is failing) must leave the last
+// known-good peer series in place rather than blanking the mesh.
+func TestPeerlessStatusDoesNotWipePeerSeries(t *testing.T) {
+	e, err := newEphemeralExporter(&types.GlobalSettings{NodeName: "test-node"})
+	if err != nil {
+		t.Fatalf("newEphemeralExporter: %v", err)
+	}
+
+	e.recordLatencyMetrics(peerStatus(
+		peer("node-a", "10.0.0.1", true, 1),
+		peer("node-b", "10.0.0.2", true, 1),
+	))
+
+	// A gateway-only status from a different monitor.
+	gwStatus := types.NewStatus("network-gateway-check")
+	gwStatus.SetLatencyMetrics(&types.LatencyMetrics{
+		Gateway: &types.GatewayLatency{GatewayIP: "10.0.0.254", LatencyMs: 1, AddressFamily: "ipv4"},
+	})
+	e.recordLatencyMetrics(gwStatus)
+
+	families, err := e.registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	if got := len(peerSeriesLabels(t, families, "test_peer_reachable")); got != 2 {
+		t.Errorf("peer_reachable has %d series after a peerless status, want 2 (must not be wiped)", got)
+	}
+	if got, _ := gaugeValueWithLabels(t, families, "test_peer_set_churn_total", map[string]string{"node": "test-node", "change": "removed"}); got != 0 {
+		t.Errorf("removed churn after a peerless status = %v, want 0", got)
+	}
+}

--- a/pkg/monitors/network/cni.go
+++ b/pkg/monitors/network/cni.go
@@ -511,12 +511,25 @@ func (m *CNIMonitor) checkCNI(ctx context.Context) (*types.Status, error) {
 	persistentlyUnreachablePeers := make([]string, 0) // Peers exceeding failure threshold
 	var totalLatency time.Duration
 
+	// The discovered peer set is AUTHORITATIVE for this cycle. Statuses are collected
+	// into a fresh map that is swapped in wholesale below, so a peer that disappeared
+	// from discovery (node removed, renamed, or re-addressed) is dropped instead of
+	// lingering forever. Before this, m.peerStatuses only ever grew: pre-rename
+	// identities kept their last-written values and were still exported as
+	// peer_latency_seconds / peer_reachable series, which pinned peer reachability
+	// below 100% and inflated max-latency alerts until the agent was restarted.
+	//
+	// This is safe against a transient discovery failure because the discovery layer
+	// itself fails safe: on a list error it keeps (and keeps serving) the previous
+	// peer set rather than returning an empty one, so `peers` here is never emptied
+	// by an API blip. The len(peers)==0 early return above is a further backstop --
+	// it leaves the previous statuses untouched and publishes no latency metrics.
+	nextStatuses := make(map[string]*PeerStatus, len(peers))
+
 	for result := range resultsCh {
 		peerStatus := result.status
 
-		m.mu.Lock()
-		m.peerStatuses[result.peer.NodeName] = peerStatus
-		m.mu.Unlock()
+		nextStatuses[result.peer.NodeName] = peerStatus
 
 		if peerStatus.Reachable {
 			reachableCount++
@@ -538,6 +551,12 @@ func (m *CNIMonitor) checkCNI(ctx context.Context) (*types.Status, error) {
 			}
 		}
 	}
+
+	// Swap in the authoritative status map for this cycle, dropping any peer that
+	// is no longer present in discovery.
+	m.mu.Lock()
+	m.peerStatuses = nextStatuses
+	m.mu.Unlock()
 
 	// Emit aggregate events only on state changes (delta-based emission, fixes issue #8)
 	// This prevents duplicate events when the same peers are problematic across checks

--- a/pkg/monitors/network/peer_discovery.go
+++ b/pkg/monitors/network/peer_discovery.go
@@ -151,9 +151,19 @@ func (d *kubernetesPeerDiscovery) GetPeers() []Peer {
 }
 
 // Refresh forces an immediate refresh of the peer list.
+//
+// On success the freshly discovered set REPLACES the previous one: peers that have
+// disappeared from the API (node removed, renamed, or re-addressed) are dropped, so a
+// long-running agent converges on the same peer set a freshly started agent would see.
+//
+// On failure the previous peer set is deliberately left intact and the error is
+// returned. A transient API/list failure must never wipe the mesh: an empty peer set
+// would make every consumer believe it has no peers to probe. Callers keep probing the
+// last known-good set until a successful list produces a new authoritative one.
 func (d *kubernetesPeerDiscovery) Refresh(ctx context.Context) error {
 	peers, err := d.discoverPeers(ctx)
 	if err != nil {
+		// Fail safe: record the error but keep d.peers as-is.
 		d.mu.Lock()
 		d.lastError = err
 		d.mu.Unlock()

--- a/pkg/monitors/network/peer_prune_test.go
+++ b/pkg/monitors/network/peer_prune_test.go
@@ -1,0 +1,415 @@
+package network
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/supporttools/node-doctor/pkg/types"
+)
+
+// recordingPinger records every target it was asked to probe, per cycle, and
+// reports every target as reachable unless listed in dead.
+type recordingPinger struct {
+	mu      sync.Mutex
+	targets []string
+	dead    map[string]bool
+}
+
+func (p *recordingPinger) Ping(_ context.Context, target string, count int, _ time.Duration) ([]PingResult, error) {
+	p.mu.Lock()
+	p.targets = append(p.targets, target)
+	dead := p.dead[target]
+	p.mu.Unlock()
+
+	results := make([]PingResult, count)
+	for i := range results {
+		results[i] = PingResult{Success: !dead, RTT: 2 * time.Millisecond, Family: "ipv4"}
+		if dead {
+			// A dead target times out at the probe timeout, which is what produced
+			// the fake 200-500ms "latency" in the incident.
+			results[i].RTT = 500 * time.Millisecond
+		}
+	}
+	return results, nil
+}
+
+func (p *recordingPinger) reset() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.targets = nil
+}
+
+func (p *recordingPinger) probed() map[string]bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := map[string]bool{}
+	for _, t := range p.targets {
+		out[t] = true
+	}
+	return out
+}
+
+func testPeer(node, ip string) Peer {
+	return Peer{Name: "nd-" + node, NodeName: node, NodeIP: ip, PodIP: ip, SameZone: true, LastSeen: time.Now()}
+}
+
+// newPruneTestMonitor builds a CNI monitor over a mutable static discovery so a
+// test can simulate peers appearing and disappearing between check cycles.
+func newPruneTestMonitor(t *testing.T, pinger Pinger, peers ...Peer) (*CNIMonitor, *staticPeerDiscovery) {
+	t.Helper()
+	discovery := NewStaticPeerDiscovery(peers)
+	static, ok := discovery.(*staticPeerDiscovery)
+	if !ok {
+		t.Fatalf("NewStaticPeerDiscovery returned %T, want *staticPeerDiscovery", discovery)
+	}
+	return &CNIMonitor{
+		name: "test-cni",
+		config: &CNIMonitorConfig{
+			Connectivity: ConnectivityConfig{
+				PingCount:         3,
+				PingTimeout:       5 * time.Second,
+				WarningLatency:    50 * time.Millisecond,
+				CriticalLatency:   200 * time.Millisecond,
+				FailureThreshold:  3,
+				MinReachablePeers: 80,
+			},
+		},
+		peerDiscovery: discovery,
+		pinger:        pinger,
+		peerStatuses:  make(map[string]*PeerStatus),
+	}, static
+}
+
+func publishedPeers(t *testing.T, status *types.Status) map[[2]string]types.PeerLatency {
+	t.Helper()
+	out := map[[2]string]types.PeerLatency{}
+	lm := status.GetLatencyMetrics()
+	if lm == nil {
+		return out
+	}
+	for _, p := range lm.Peers {
+		out[[2]string{p.PeerNode, p.PeerIP}] = p
+	}
+	return out
+}
+
+// TestPeerRemovedFromDiscoveryIsDroppedNextCycle is the core regression test for
+// node-doctor-251: the CNI monitor's peerStatuses map only ever grew, so a peer
+// that disappeared from discovery kept being published as a latency/reachability
+// series at its last written value until the agent was restarted.
+func TestPeerRemovedFromDiscoveryIsDroppedNextCycle(t *testing.T) {
+	pinger := &recordingPinger{dead: map[string]bool{"10.0.0.4": true}}
+	m, discovery := newPruneTestMonitor(t, pinger,
+		testPeer("node-a", "10.0.0.1"),
+		testPeer("node-b", "10.0.0.2"),
+		testPeer("node-c", "10.0.0.3"),
+		testPeer("node-dead", "10.0.0.4"),
+	)
+
+	ctx := context.Background()
+
+	// Cycle 1: the doomed node is still in discovery but already unreachable.
+	first, err := m.checkCNI(ctx)
+	if err != nil {
+		t.Fatalf("checkCNI: %v", err)
+	}
+	if got := len(publishedPeers(t, first)); got != 4 {
+		t.Fatalf("cycle 1 published %d peers, want 4", got)
+	}
+
+	// The node is removed/renamed; discovery no longer returns it.
+	discovery.SetPeers([]Peer{
+		testPeer("node-a", "10.0.0.1"),
+		testPeer("node-b", "10.0.0.2"),
+		testPeer("node-c", "10.0.0.3"),
+	})
+	pinger.reset()
+
+	second, err := m.checkCNI(ctx)
+	if err != nil {
+		t.Fatalf("checkCNI: %v", err)
+	}
+
+	// It must not be probed any more...
+	if pinger.probed()["10.0.0.4"] {
+		t.Error("removed peer 10.0.0.4 was still probed after it left discovery")
+	}
+
+	// ...and it must not be tracked or published any more.
+	m.mu.Lock()
+	_, tracked := m.peerStatuses["node-dead"]
+	trackedCount := len(m.peerStatuses)
+	m.mu.Unlock()
+	if tracked {
+		t.Error("peerStatuses still holds node-dead after it left discovery")
+	}
+	if trackedCount != 3 {
+		t.Errorf("peerStatuses has %d entries, want 3", trackedCount)
+	}
+
+	published := publishedPeers(t, second)
+	if len(published) != 3 {
+		t.Errorf("cycle 2 published %d peers, want 3: %v", len(published), published)
+	}
+	if _, stale := published[[2]string{"node-dead", "10.0.0.4"}]; stale {
+		t.Error("cycle 2 still publishes latency metrics for the removed peer")
+	}
+
+	// The whole point: reachability must read 100%, not the 3-of-4 = 75% that a
+	// retained dead peer produces on every long-lived agent.
+	reachable := 0
+	for _, p := range published {
+		if p.Reachable {
+			reachable++
+		}
+	}
+	if reachable != len(published) {
+		t.Errorf("reachable %d/%d, want all peers reachable", reachable, len(published))
+	}
+	for k, p := range published {
+		if p.LatencyMs > 100 {
+			t.Errorf("peer %v published %.1fms latency; a dead peer's timeout is leaking into max-latency alerting", k, p.LatencyMs)
+		}
+	}
+}
+
+// TestRenamedPeerLeavesNoOldIdentity covers the incident's rename/re-address
+// pattern: a1pidnsp02/172.28.1.41 became a1pinode01/172.28.1.14. Neither the old
+// name nor the old address may survive the next cycle.
+func TestRenamedPeerLeavesNoOldIdentity(t *testing.T) {
+	pinger := &recordingPinger{dead: map[string]bool{"172.28.1.41": true}}
+	m, discovery := newPruneTestMonitor(t, pinger,
+		testPeer("a1pidnsp02", "172.28.1.41"),
+		testPeer("a1pinode02", "172.28.1.15"),
+	)
+
+	ctx := context.Background()
+	if _, err := m.checkCNI(ctx); err != nil {
+		t.Fatalf("checkCNI: %v", err)
+	}
+
+	discovery.SetPeers([]Peer{
+		testPeer("a1pinode01", "172.28.1.14"),
+		testPeer("a1pinode02", "172.28.1.15"),
+	})
+	pinger.reset()
+
+	status, err := m.checkCNI(ctx)
+	if err != nil {
+		t.Fatalf("checkCNI: %v", err)
+	}
+
+	if pinger.probed()["172.28.1.41"] {
+		t.Error("the pre-rename address 172.28.1.41 is still being probed")
+	}
+
+	m.mu.Lock()
+	_, oldName := m.peerStatuses["a1pidnsp02"]
+	count := len(m.peerStatuses)
+	m.mu.Unlock()
+	if oldName {
+		t.Error("peerStatuses still holds the pre-rename node name a1pidnsp02")
+	}
+	if count != 2 {
+		t.Errorf("peerStatuses has %d entries, want 2", count)
+	}
+
+	published := publishedPeers(t, status)
+	if _, stale := published[[2]string{"a1pidnsp02", "172.28.1.41"}]; stale {
+		t.Error("the pre-rename identity is still published")
+	}
+	if _, ok := published[[2]string{"a1pinode01", "172.28.1.14"}]; !ok {
+		t.Error("the post-rename identity is missing from published peers")
+	}
+}
+
+// TestPeerSetConvergesRegardlessOfHistory proves the fix is history-independent:
+// a monitor that has churned through many peer identities ends up with exactly the
+// same peer set as a freshly constructed one. Agent uptime must not change the
+// answer -- that correlation was the incident's tell.
+func TestPeerSetConvergesRegardlessOfHistory(t *testing.T) {
+	final := []Peer{
+		testPeer("node-a", "10.0.0.1"),
+		testPeer("node-b", "10.0.0.2"),
+	}
+
+	ctx := context.Background()
+
+	fresh, _ := newPruneTestMonitor(t, &recordingPinger{}, final...)
+	freshStatus, err := fresh.checkCNI(ctx)
+	if err != nil {
+		t.Fatalf("checkCNI: %v", err)
+	}
+
+	aged, discovery := newPruneTestMonitor(t, &recordingPinger{dead: map[string]bool{
+		"172.28.1.41": true, "172.28.1.43": true, "10.9.9.9": true,
+	}})
+	for _, generation := range [][]Peer{
+		{testPeer("a1pinode01", "172.28.1.41"), testPeer("a1pinode03", "172.28.1.43")},
+		{testPeer("a1pidnsp02", "172.28.1.41"), testPeer("phantom", "10.9.9.9")},
+		{testPeer("node-a", "10.0.0.1")},
+		final,
+	} {
+		discovery.SetPeers(generation)
+		if _, err := aged.checkCNI(ctx); err != nil {
+			t.Fatalf("checkCNI: %v", err)
+		}
+	}
+	agedStatus, err := aged.checkCNI(ctx)
+	if err != nil {
+		t.Fatalf("checkCNI: %v", err)
+	}
+
+	freshPeers := publishedPeers(t, freshStatus)
+	agedPeers := publishedPeers(t, agedStatus)
+	if len(agedPeers) != len(freshPeers) {
+		t.Fatalf("aged agent publishes %d peers, fresh agent publishes %d; peer set must not depend on uptime: %v", len(agedPeers), len(freshPeers), agedPeers)
+	}
+	for k := range freshPeers {
+		if _, ok := agedPeers[k]; !ok {
+			t.Errorf("aged agent is missing peer %v", k)
+		}
+	}
+	for k := range agedPeers {
+		if _, ok := freshPeers[k]; !ok {
+			t.Errorf("aged agent still carries stale peer %v", k)
+		}
+	}
+}
+
+// TestDiscoveryErrorKeepsPreviousPeerSet is the fail-safe guard for the replace
+// approach: a transient API/list failure must NOT wipe the peer set. Replacing it
+// with an empty set would make every agent believe the mesh is gone.
+func TestDiscoveryErrorKeepsPreviousPeerSet(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		runningPodOn("nd-self", "self", "10.0.0.1"),
+		runningPodOn("nd-a", "node-a", "10.0.0.2"),
+		runningPodOn("nd-b", "node-b", "10.0.0.3"),
+	)
+	pd, err := NewKubernetesPeerDiscoveryWithClient(&PeerDiscoveryConfig{
+		Namespace:     "node-doctor",
+		LabelSelector: "app=node-doctor",
+		SelfNodeName:  "self",
+	}, client)
+	if err != nil {
+		t.Fatalf("NewKubernetesPeerDiscoveryWithClient: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := pd.Refresh(ctx); err != nil {
+		t.Fatalf("initial Refresh: %v", err)
+	}
+	before := pd.GetPeers()
+	if len(before) != 2 {
+		t.Fatalf("got %d peers, want 2", len(before))
+	}
+
+	// Now make the pod list fail, as a transient apiserver outage would.
+	listErr := errors.New("etcdserver: request timed out")
+	client.PrependReactor("list", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, listErr
+	})
+
+	if err := pd.Refresh(ctx); !errors.Is(err, listErr) {
+		t.Fatalf("Refresh error = %v, want it to surface the list failure", err)
+	}
+
+	after := pd.GetPeers()
+	if len(after) != 2 {
+		t.Fatalf("peer set has %d entries after a discovery error, want the previous 2 kept (fail safe)", len(after))
+	}
+	byNode := map[string]Peer{}
+	for _, p := range after {
+		byNode[p.NodeName] = p
+	}
+	for _, want := range []string{"node-a", "node-b"} {
+		if _, ok := byNode[want]; !ok {
+			t.Errorf("peer %s was lost by a failed discovery pass", want)
+		}
+	}
+}
+
+// TestDiscoveryReplacesRenamedPeer verifies the discovery layer itself is
+// authoritative: a node that is renamed and re-addressed in the API produces only
+// the new identity, never a merged old+new set.
+func TestDiscoveryReplacesRenamedPeer(t *testing.T) {
+	oldPod := runningPodOn("nd-old", "a1pidnsp02", "172.28.1.41")
+	client := fake.NewSimpleClientset(
+		runningPodOn("nd-self", "self", "10.0.0.1"),
+		oldPod,
+	)
+	pd, err := NewKubernetesPeerDiscoveryWithClient(&PeerDiscoveryConfig{
+		Namespace:     "node-doctor",
+		LabelSelector: "app=node-doctor",
+		SelfNodeName:  "self",
+	}, client)
+	if err != nil {
+		t.Fatalf("NewKubernetesPeerDiscoveryWithClient: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := pd.Refresh(ctx); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if got := len(pd.GetPeers()); got != 1 {
+		t.Fatalf("got %d peers, want 1", got)
+	}
+
+	// The Pi node is renamed and re-addressed: old pod gone, new pod present.
+	if err := client.CoreV1().Pods("node-doctor").Delete(ctx, "nd-old", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := client.CoreV1().Pods("node-doctor").Create(ctx, runningPodOn("nd-new", "a1pinode01", "172.28.1.14"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := pd.Refresh(ctx); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	peers := pd.GetPeers()
+	if len(peers) != 1 {
+		t.Fatalf("got %d peers after rename, want 1: %+v", len(peers), peers)
+	}
+	if peers[0].NodeName != "a1pinode01" || peers[0].NodeIP != "172.28.1.14" {
+		t.Errorf("peer = %s/%s, want a1pinode01/172.28.1.14", peers[0].NodeName, peers[0].NodeIP)
+	}
+}
+
+// TestDiscoveryStartFailureLeavesEmptySetNotStale documents the startup case: an
+// agent whose very first discovery fails has no peers at all (nothing to keep),
+// and the CNI monitor reports NoPeersFound rather than probing phantom targets.
+func TestDiscoveryStartFailureLeavesEmptySetNotStale(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("list", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("connection refused")
+	})
+	pd, err := NewKubernetesPeerDiscoveryWithClient(&PeerDiscoveryConfig{
+		Namespace:     "node-doctor",
+		LabelSelector: "app=node-doctor",
+		SelfNodeName:  "self",
+		// Long interval: the background goroutine must not fire during the test.
+		RefreshInterval: time.Hour,
+	}, client)
+	if err != nil {
+		t.Fatalf("NewKubernetesPeerDiscoveryWithClient: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := pd.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer pd.Stop()
+
+	if got := len(pd.GetPeers()); got != 0 {
+		t.Errorf("got %d peers after a failed initial discovery, want 0", got)
+	}
+}


### PR DESCRIPTION
## Problem

node-doctor's peer mesh accumulated dead peers and only ever cleared them on restart. Peer-set contents correlated perfectly with agent uptime: freshly restarted agents held the correct 12-peer list, while eight agents up ~24.7h held 16 peers, four of them pre-rename / pre-re-address identities of the Pi nodes (`.41/.43` -> `.14/.15`).

## Root cause — it was not the discovery layer

`kubernetesPeerDiscovery.Refresh` was already correct: on success it replaces the peer set wholesale, and on a list error it returns the error and leaves the previous set intact. The accumulation was in the two caches **downstream** of discovery, both of which only ever grew:

1. **`CNIMonitor.peerStatuses`** (keyed by node name) was written per discovered peer and never pruned. Its full contents — not the discovered set — are what get published as `LatencyMetrics.Peers` each cycle, so vanished peers kept being exported at their last written values.
2. **Prometheus `*Vec` collectors** retain every label combination they have ever been handed. Even with (1) fixed, a renamed or re-addressed peer left its old `(peer_node, peer_ip, address_family)` gauge series behind forever.

Together these reproduce the reported downstream symptoms exactly:

- `avg by (node, address_family) (node_doctor_monitor_peer_reachable)` pinned at **exactly 75.0%** — one frozen `peer_reachable=0` out of four — which is why eight nodes all reported the identical value.
- `max by (node) (node_doctor_monitor_peer_latency_seconds)` reporting a dead target's last timeout as 200-500ms of fake latency.

## Fix: replace, not age out

Discovery is already atomic and already fails safe, so extending its authoritative-replace semantics to both downstream caches keeps one model end to end. An age-out TTL would add state and would still serve the false 75% for N cycles before expiring.

- `checkCNI` builds a fresh `peerStatuses` map from this cycle's discovered set and swaps it in.
- The exporter diffs published peer identities against the previous cycle and deletes the gauge series for identities that are gone (`peer_latency_seconds`, `peer_latency_avg_seconds`, `peer_reachable`, plus the histogram when the peer name itself disappears).

### Discovery-error edge case

A transient API/list failure must never wipe the mesh. Three layers hold:

- `Refresh` keeps the previous peer set on a list error (now documented, now tested), so `GetPeers` never goes empty from an API blip.
- `checkCNI` returns early on an empty peer set without touching `peerStatuses` and without publishing latency metrics.
- The exporter reconciles only when the status actually carries peers, so a peerless status (another monitor's latency, or a peerless CNI cycle) never deletes peer series.

## New metrics

| Metric | Type | Labels | Notes |
|---|---|---|---|
| `node_doctor_monitor_peer_set_size` | Gauge | `node` | Should equal (nodes - 1) on every node regardless of agent uptime. A node reporting more than its neighbours is holding stale peers. |
| `node_doctor_monitor_peer_set_churn_total` | Counter | `node`, `change="added"\|"removed"` | A rename or re-address is one removal plus one addition. Both series are initialised at 0 so `rate()`/`increase()` are well defined. |

## Tests

`pkg/monitors/network/peer_prune_test.go` and `pkg/exporters/prometheus/peer_series_prune_test.go`:

- a peer removed from discovery is not probed and not published on the very next cycle
- a renamed/re-addressed peer leaves neither the old name nor the old IP behind (uses the incident's real identities, `a1pidnsp02/172.28.1.41` -> `a1pinode01/172.28.1.14`)
- an aged monitor that has churned through many identities converges on the exact peer set a fresh one reports — uptime independence, the incident's tell
- a discovery error keeps the previous peer set; a peerless status does not wipe peer series
- peer-set size and churn track reality across add / re-address / remove

Every one of these fails against the pre-fix code (verified by reverting the two source files and re-running); the two fail-safe guards pass in both directions by design.

`make build`, `make test`, and `go test -race ./pkg/monitors/network/ ./pkg/exporters/prometheus/` all pass.

## Verification note

The 2026-08-12 rollout restarted every agent, so the live fleet currently reads clean (12 peers, 0 unreachable) regardless of this change. That is the expected post-restart state and is **not** evidence about this fix in either direction — correctness here is established by the tests above. No cluster was touched.

No Helm chart changes, so no `values.yaml` regeneration is involved.

Task: #node-doctor-251

https://claude.ai/code/session_01Av4whriQf6KqJgRxGKQP7N
